### PR TITLE
Override swagger ui theme

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 }
 
 scmPlugin {
-  scmVersion = "2.0.0"
+  scmVersion = "2.31.2-SNAPSHOT"
 
   displayName = "OpenAPI"
   description = "OpenAPI-spec and SwaggerUI for SCM-Manager"

--- a/gradle/changelog/override_colors.yaml
+++ b/gradle/changelog/override_colors.yaml
@@ -1,0 +1,2 @@
+- type: changed
+  description: Override swagger ui theme ([#29](https://github.com/scm-manager/scm-openapi-plugin/pull/29))

--- a/src/main/js/SwaggerUI.tsx
+++ b/src/main/js/SwaggerUI.tsx
@@ -24,6 +24,7 @@
 import React, { FC, useEffect, useState } from "react";
 import SwaggerUIReact from "swagger-ui-react";
 import "swagger-ui-react/swagger-ui.css";
+import "./swaggerUIColors.css";
 import { apiClient, ErrorPage, Loading } from "@scm-manager/ui-components";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";

--- a/src/main/js/swaggerUIColors.css
+++ b/src/main/js/swaggerUIColors.css
@@ -31,6 +31,7 @@
 
 .swagger-ui .opblock-tag,
 .swagger-ui .opblock-tag small,
+.swagger-ui .opblock-tag svg,
 .swagger-ui .parameter__type {
   color: var(--scm-secondary-text)
 }

--- a/src/main/js/swaggerUIColors.css
+++ b/src/main/js/swaggerUIColors.css
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 .swagger-ui {
   color: var(--scm-secondary-text);
 }

--- a/src/main/js/swaggerUIColors.css
+++ b/src/main/js/swaggerUIColors.css
@@ -315,7 +315,7 @@
 }
 
 .swagger-ui .model-title {
-  color: var(--scm-dark-color)
+  color: var(--scm-secondary-more-color)
 }
 
 .swagger-ui .model-deprecated-warning {
@@ -332,6 +332,18 @@
 
 .swagger-ui table.headers td {
   color: var(--scm-secondary-text)
+}
+
+.swagger-ui table.model tr.property-row td:first-child {
+  color: var(--scm-secondary-text)
+}
+
+.swagger-ui span.prop-type {
+  color: var(--scm-info-color)
+}
+
+.swagger-ui span.prop-enum {
+  color: var(--scm-info-color)
 }
 
 .swagger-ui table thead tr td,

--- a/src/main/js/swaggerUIColors.css
+++ b/src/main/js/swaggerUIColors.css
@@ -1,0 +1,2115 @@
+.swagger-ui {
+  color: #3b4151
+}
+
+.swagger-ui mark {
+  background-color: #ff0;
+  color: #000
+}
+
+.swagger-ui .debug * {
+  outline: 1px solid gold
+}
+
+.swagger-ui .debug-white * {
+  outline: 1px solid #fff
+}
+
+.swagger-ui .debug-black * {
+  outline: 1px solid #000
+}
+
+.swagger-ui .debug-grid {
+  background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyhpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTExIDc5LjE1ODMyNSwgMjAxNS8wOS8xMC0wMToxMDoyMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MTRDOTY4N0U2N0VFMTFFNjg2MzZDQjkwNkQ4MjgwMEIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MTRDOTY4N0Q2N0VFMTFFNjg2MzZDQjkwNkQ4MjgwMEIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTUgKE1hY2ludG9zaCkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo3NjcyQkQ3NjY3QzUxMUU2QjJCQ0UyNDA4MTAwMjE3MSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo3NjcyQkQ3NzY3QzUxMUU2QjJCQ0UyNDA4MTAwMjE3MSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PsBS+GMAAAAjSURBVHjaYvz//z8DLsD4gcGXiYEAGBIKGBne//fFpwAgwAB98AaF2pjlUQAAAABJRU5ErkJggg==) repeat 0 0
+}
+
+.swagger-ui .debug-grid-16 {
+  background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyhpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTExIDc5LjE1ODMyNSwgMjAxNS8wOS8xMC0wMToxMDoyMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6ODYyRjhERDU2N0YyMTFFNjg2MzZDQjkwNkQ4MjgwMEIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6ODYyRjhERDQ2N0YyMTFFNjg2MzZDQjkwNkQ4MjgwMEIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTUgKE1hY2ludG9zaCkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo3NjcyQkQ3QTY3QzUxMUU2QjJCQ0UyNDA4MTAwMjE3MSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo3NjcyQkQ3QjY3QzUxMUU2QjJCQ0UyNDA4MTAwMjE3MSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PvCS01IAAABMSURBVHjaYmR4/5+BFPBfAMFm/MBgx8RAGWCn1AAmSg34Q6kBDKMGMDCwICeMIemF/5QawEipAWwUhwEjMDvbAWlWkvVBwu8vQIABAEwBCph8U6c0AAAAAElFTkSuQmCC) repeat 0 0
+}
+
+.swagger-ui .debug-grid-8-solid {
+  background: #fff url(data:image/jpeg;base64,/9j/4QAYRXhpZgAASUkqAAgAAAAAAAAAAAAAAP/sABFEdWNreQABAAQAAAAAAAD/4QMxaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLwA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/PiA8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjYtYzExMSA3OS4xNTgzMjUsIDIwMTUvMDkvMTAtMDE6MTA6MjAgICAgICAgICI+IDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+IDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bXA6Q3JlYXRvclRvb2w9IkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOkIxMjI0OTczNjdCMzExRTZCMkJDRTI0MDgxMDAyMTcxIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOkIxMjI0OTc0NjdCMzExRTZCMkJDRTI0MDgxMDAyMTcxIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6QjEyMjQ5NzE2N0IzMTFFNkIyQkNFMjQwODEwMDIxNzEiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6QjEyMjQ5NzI2N0IzMTFFNkIyQkNFMjQwODEwMDIxNzEiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz7/7gAOQWRvYmUAZMAAAAAB/9sAhAAbGhopHSlBJiZBQi8vL0JHPz4+P0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHAR0pKTQmND8oKD9HPzU/R0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0f/wAARCAAIAAgDASIAAhEBAxEB/8QAWQABAQAAAAAAAAAAAAAAAAAAAAYBAQEAAAAAAAAAAAAAAAAAAAIEEAEBAAMBAAAAAAAAAAAAAAABADECA0ERAAEDBQAAAAAAAAAAAAAAAAARITFBUWESIv/aAAwDAQACEQMRAD8AoOnTV1QTD7JJshP3vSM3P//Z) repeat 0 0
+}
+
+.swagger-ui .debug-grid-16-solid {
+  background: #fff url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyhpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTExIDc5LjE1ODMyNSwgMjAxNS8wOS8xMC0wMToxMDoyMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTUgKE1hY2ludG9zaCkiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6NzY3MkJEN0U2N0M1MTFFNkIyQkNFMjQwODEwMDIxNzEiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6NzY3MkJEN0Y2N0M1MTFFNkIyQkNFMjQwODEwMDIxNzEiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo3NjcyQkQ3QzY3QzUxMUU2QjJCQ0UyNDA4MTAwMjE3MSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo3NjcyQkQ3RDY3QzUxMUU2QjJCQ0UyNDA4MTAwMjE3MSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pve6J3kAAAAzSURBVHjaYvz//z8D0UDsMwMjSRoYP5Gq4SPNbRjVMEQ1fCRDg+in/6+J1AJUxsgAEGAA31BAJMS0GYEAAAAASUVORK5CYII=) repeat 0 0
+}
+
+.swagger-ui .b--black {
+  border-color: #000
+}
+
+.swagger-ui .b--near-black {
+  border-color: #111
+}
+
+.swagger-ui .b--dark-gray {
+  border-color: #333
+}
+
+.swagger-ui .b--mid-gray {
+  border-color: #555
+}
+
+.swagger-ui .b--gray {
+  border-color: #777
+}
+
+.swagger-ui .b--silver {
+  border-color: #999
+}
+
+.swagger-ui .b--light-silver {
+  border-color: #aaa
+}
+
+.swagger-ui .b--moon-gray {
+  border-color: #ccc
+}
+
+.swagger-ui .b--light-gray {
+  border-color: #eee
+}
+
+.swagger-ui .b--near-white {
+  border-color: #f4f4f4
+}
+
+.swagger-ui .b--white {
+  border-color: #fff
+}
+
+.swagger-ui .b--white-90 {
+  border-color: hsla(0, 0%, 100%, .9)
+}
+
+.swagger-ui .b--white-80 {
+  border-color: hsla(0, 0%, 100%, .8)
+}
+
+.swagger-ui .b--white-70 {
+  border-color: hsla(0, 0%, 100%, .7)
+}
+
+.swagger-ui .b--white-60 {
+  border-color: hsla(0, 0%, 100%, .6)
+}
+
+.swagger-ui .b--white-50 {
+  border-color: hsla(0, 0%, 100%, .5)
+}
+
+.swagger-ui .b--white-40 {
+  border-color: hsla(0, 0%, 100%, .4)
+}
+
+.swagger-ui .b--white-30 {
+  border-color: hsla(0, 0%, 100%, .3)
+}
+
+.swagger-ui .b--white-20 {
+  border-color: hsla(0, 0%, 100%, .2)
+}
+
+.swagger-ui .b--white-10 {
+  border-color: hsla(0, 0%, 100%, .1)
+}
+
+.swagger-ui .b--white-05 {
+  border-color: hsla(0, 0%, 100%, .05)
+}
+
+.swagger-ui .b--white-025 {
+  border-color: hsla(0, 0%, 100%, .025)
+}
+
+.swagger-ui .b--white-0125 {
+  border-color: hsla(0, 0%, 100%, .0125)
+}
+
+.swagger-ui .b--black-90 {
+  border-color: rgba(0, 0, 0, .9)
+}
+
+.swagger-ui .b--black-80 {
+  border-color: rgba(0, 0, 0, .8)
+}
+
+.swagger-ui .b--black-70 {
+  border-color: rgba(0, 0, 0, .7)
+}
+
+.swagger-ui .b--black-60 {
+  border-color: rgba(0, 0, 0, .6)
+}
+
+.swagger-ui .b--black-50 {
+  border-color: rgba(0, 0, 0, .5)
+}
+
+.swagger-ui .b--black-40 {
+  border-color: rgba(0, 0, 0, .4)
+}
+
+.swagger-ui .b--black-30 {
+  border-color: rgba(0, 0, 0, .3)
+}
+
+.swagger-ui .b--black-20 {
+  border-color: rgba(0, 0, 0, .2)
+}
+
+.swagger-ui .b--black-10 {
+  border-color: rgba(0, 0, 0, .1)
+}
+
+.swagger-ui .b--black-05 {
+  border-color: rgba(0, 0, 0, .05)
+}
+
+.swagger-ui .b--black-025 {
+  border-color: rgba(0, 0, 0, .025)
+}
+
+.swagger-ui .b--black-0125 {
+  border-color: rgba(0, 0, 0, .0125)
+}
+
+.swagger-ui .b--dark-red {
+  border-color: #e7040f
+}
+
+.swagger-ui .b--red {
+  border-color: #ff4136
+}
+
+.swagger-ui .b--light-red {
+  border-color: #ff725c
+}
+
+.swagger-ui .b--orange {
+  border-color: #ff6300
+}
+
+.swagger-ui .b--gold {
+  border-color: #ffb700
+}
+
+.swagger-ui .b--yellow {
+  border-color: gold
+}
+
+.swagger-ui .b--light-yellow {
+  border-color: #fbf1a9
+}
+
+.swagger-ui .b--purple {
+  border-color: #5e2ca5
+}
+
+.swagger-ui .b--light-purple {
+  border-color: #a463f2
+}
+
+.swagger-ui .b--dark-pink {
+  border-color: #d5008f
+}
+
+.swagger-ui .b--hot-pink {
+  border-color: #ff41b4
+}
+
+.swagger-ui .b--pink {
+  border-color: #ff80cc
+}
+
+.swagger-ui .b--light-pink {
+  border-color: #ffa3d7
+}
+
+.swagger-ui .b--dark-green {
+  border-color: #137752
+}
+
+.swagger-ui .b--green {
+  border-color: #19a974
+}
+
+.swagger-ui .b--light-green {
+  border-color: #9eebcf
+}
+
+.swagger-ui .b--navy {
+  border-color: #001b44
+}
+
+.swagger-ui .b--dark-blue {
+  border-color: #00449e
+}
+
+.swagger-ui .b--blue {
+  border-color: #357edd
+}
+
+.swagger-ui .b--light-blue {
+  border-color: #96ccff
+}
+
+.swagger-ui .b--lightest-blue {
+  border-color: #cdecff
+}
+
+.swagger-ui .b--washed-blue {
+  border-color: #f6fffe
+}
+
+.swagger-ui .b--washed-green {
+  border-color: #e8fdf5
+}
+
+.swagger-ui .b--washed-yellow {
+  border-color: #fffceb
+}
+
+.swagger-ui .b--washed-red {
+  border-color: #ffdfdf
+}
+
+.swagger-ui .b--transparent {
+  border-color: transparent
+}
+
+.swagger-ui .b--inherit {
+  border-color: inherit
+}
+
+.swagger-ui .shadow-1 {
+  box-shadow: 0 0 4px 2px rgba(0, 0, 0, .2)
+}
+
+.swagger-ui .shadow-2 {
+  box-shadow: 0 0 8px 2px rgba(0, 0, 0, .2)
+}
+
+.swagger-ui .shadow-3 {
+  box-shadow: 2px 2px 4px 2px rgba(0, 0, 0, .2)
+}
+
+.swagger-ui .shadow-4 {
+  box-shadow: 2px 2px 8px 0 rgba(0, 0, 0, .2)
+}
+
+.swagger-ui .shadow-5 {
+  box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, .2)
+}
+
+@media screen and (min-width:30em) {
+  .swagger-ui .shadow-1-ns {
+    box-shadow: 0 0 4px 2px rgba(0, 0, 0, .2)
+  }
+  .swagger-ui .shadow-2-ns {
+    box-shadow: 0 0 8px 2px rgba(0, 0, 0, .2)
+  }
+  .swagger-ui .shadow-3-ns {
+    box-shadow: 2px 2px 4px 2px rgba(0, 0, 0, .2)
+  }
+  .swagger-ui .shadow-4-ns {
+    box-shadow: 2px 2px 8px 0 rgba(0, 0, 0, .2)
+  }
+  .swagger-ui .shadow-5-ns {
+    box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, .2)
+  }
+}
+
+@media screen and (min-width:30em) and (max-width:60em) {
+  .swagger-ui .shadow-1-m {
+    box-shadow: 0 0 4px 2px rgba(0, 0, 0, .2)
+  }
+  .swagger-ui .shadow-2-m {
+    box-shadow: 0 0 8px 2px rgba(0, 0, 0, .2)
+  }
+  .swagger-ui .shadow-3-m {
+    box-shadow: 2px 2px 4px 2px rgba(0, 0, 0, .2)
+  }
+  .swagger-ui .shadow-4-m {
+    box-shadow: 2px 2px 8px 0 rgba(0, 0, 0, .2)
+  }
+  .swagger-ui .shadow-5-m {
+    box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, .2)
+  }
+}
+
+@media screen and (min-width:60em) {
+  .swagger-ui .shadow-1-l {
+    box-shadow: 0 0 4px 2px rgba(0, 0, 0, .2)
+  }
+  .swagger-ui .shadow-2-l {
+    box-shadow: 0 0 8px 2px rgba(0, 0, 0, .2)
+  }
+  .swagger-ui .shadow-3-l {
+    box-shadow: 2px 2px 4px 2px rgba(0, 0, 0, .2)
+  }
+  .swagger-ui .shadow-4-l {
+    box-shadow: 2px 2px 8px 0 rgba(0, 0, 0, .2)
+  }
+  .swagger-ui .shadow-5-l {
+    box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, .2)
+  }
+}
+
+.swagger-ui .black-90 {
+  color: rgba(0, 0, 0, .9)
+}
+
+.swagger-ui .black-80 {
+  color: rgba(0, 0, 0, .8)
+}
+
+.swagger-ui .black-70 {
+  color: rgba(0, 0, 0, .7)
+}
+
+.swagger-ui .black-60 {
+  color: rgba(0, 0, 0, .6)
+}
+
+.swagger-ui .black-50 {
+  color: rgba(0, 0, 0, .5)
+}
+
+.swagger-ui .black-40 {
+  color: rgba(0, 0, 0, .4)
+}
+
+.swagger-ui .black-30 {
+  color: rgba(0, 0, 0, .3)
+}
+
+.swagger-ui .black-20 {
+  color: rgba(0, 0, 0, .2)
+}
+
+.swagger-ui .black-10 {
+  color: rgba(0, 0, 0, .1)
+}
+
+.swagger-ui .black-05 {
+  color: rgba(0, 0, 0, .05)
+}
+
+.swagger-ui .white-90 {
+  color: hsla(0, 0%, 100%, .9)
+}
+
+.swagger-ui .white-80 {
+  color: hsla(0, 0%, 100%, .8)
+}
+
+.swagger-ui .white-70 {
+  color: hsla(0, 0%, 100%, .7)
+}
+
+.swagger-ui .white-60 {
+  color: hsla(0, 0%, 100%, .6)
+}
+
+.swagger-ui .white-50 {
+  color: hsla(0, 0%, 100%, .5)
+}
+
+.swagger-ui .white-40 {
+  color: hsla(0, 0%, 100%, .4)
+}
+
+.swagger-ui .white-30 {
+  color: hsla(0, 0%, 100%, .3)
+}
+
+.swagger-ui .white-20 {
+  color: hsla(0, 0%, 100%, .2)
+}
+
+.swagger-ui .white-10 {
+  color: hsla(0, 0%, 100%, .1)
+}
+
+.swagger-ui .black {
+  color: #000
+}
+
+.swagger-ui .near-black {
+  color: #111
+}
+
+.swagger-ui .dark-gray {
+  color: #333
+}
+
+.swagger-ui .mid-gray {
+  color: #555
+}
+
+.swagger-ui .gray {
+  color: #777
+}
+
+.swagger-ui .silver {
+  color: #999
+}
+
+.swagger-ui .light-silver {
+  color: #aaa
+}
+
+.swagger-ui .moon-gray {
+  color: #ccc
+}
+
+.swagger-ui .light-gray {
+  color: #eee
+}
+
+.swagger-ui .near-white {
+  color: #f4f4f4
+}
+
+.swagger-ui .white {
+  color: #fff
+}
+
+.swagger-ui .dark-red {
+  color: #e7040f
+}
+
+.swagger-ui .red {
+  color: #ff4136
+}
+
+.swagger-ui .light-red {
+  color: #ff725c
+}
+
+.swagger-ui .orange {
+  color: #ff6300
+}
+
+.swagger-ui .gold {
+  color: #ffb700
+}
+
+.swagger-ui .yellow {
+  color: gold
+}
+
+.swagger-ui .light-yellow {
+  color: #fbf1a9
+}
+
+.swagger-ui .purple {
+  color: #5e2ca5
+}
+
+.swagger-ui .light-purple {
+  color: #a463f2
+}
+
+.swagger-ui .dark-pink {
+  color: #d5008f
+}
+
+.swagger-ui .hot-pink {
+  color: #ff41b4
+}
+
+.swagger-ui .pink {
+  color: #ff80cc
+}
+
+.swagger-ui .light-pink {
+  color: #ffa3d7
+}
+
+.swagger-ui .dark-green {
+  color: #137752
+}
+
+.swagger-ui .green {
+  color: #19a974
+}
+
+.swagger-ui .light-green {
+  color: #9eebcf
+}
+
+.swagger-ui .navy {
+  color: #001b44
+}
+
+.swagger-ui .dark-blue {
+  color: #00449e
+}
+
+.swagger-ui .blue {
+  color: #357edd
+}
+
+.swagger-ui .light-blue {
+  color: #96ccff
+}
+
+.swagger-ui .lightest-blue {
+  color: #cdecff
+}
+
+.swagger-ui .washed-blue {
+  color: #f6fffe
+}
+
+.swagger-ui .washed-green {
+  color: #e8fdf5
+}
+
+.swagger-ui .washed-yellow {
+  color: #fffceb
+}
+
+.swagger-ui .washed-red {
+  color: #ffdfdf
+}
+
+.swagger-ui .color-inherit {
+  color: inherit
+}
+
+.swagger-ui .bg-black-90 {
+  background-color: rgba(0, 0, 0, .9)
+}
+
+.swagger-ui .bg-black-80 {
+  background-color: rgba(0, 0, 0, .8)
+}
+
+.swagger-ui .bg-black-70 {
+  background-color: rgba(0, 0, 0, .7)
+}
+
+.swagger-ui .bg-black-60 {
+  background-color: rgba(0, 0, 0, .6)
+}
+
+.swagger-ui .bg-black-50 {
+  background-color: rgba(0, 0, 0, .5)
+}
+
+.swagger-ui .bg-black-40 {
+  background-color: rgba(0, 0, 0, .4)
+}
+
+.swagger-ui .bg-black-30 {
+  background-color: rgba(0, 0, 0, .3)
+}
+
+.swagger-ui .bg-black-20 {
+  background-color: rgba(0, 0, 0, .2)
+}
+
+.swagger-ui .bg-black-10 {
+  background-color: rgba(0, 0, 0, .1)
+}
+
+.swagger-ui .bg-black-05 {
+  background-color: rgba(0, 0, 0, .05)
+}
+
+.swagger-ui .bg-white-90 {
+  background-color: hsla(0, 0%, 100%, .9)
+}
+
+.swagger-ui .bg-white-80 {
+  background-color: hsla(0, 0%, 100%, .8)
+}
+
+.swagger-ui .bg-white-70 {
+  background-color: hsla(0, 0%, 100%, .7)
+}
+
+.swagger-ui .bg-white-60 {
+  background-color: hsla(0, 0%, 100%, .6)
+}
+
+.swagger-ui .bg-white-50 {
+  background-color: hsla(0, 0%, 100%, .5)
+}
+
+.swagger-ui .bg-white-40 {
+  background-color: hsla(0, 0%, 100%, .4)
+}
+
+.swagger-ui .bg-white-30 {
+  background-color: hsla(0, 0%, 100%, .3)
+}
+
+.swagger-ui .bg-white-20 {
+  background-color: hsla(0, 0%, 100%, .2)
+}
+
+.swagger-ui .bg-white-10 {
+  background-color: hsla(0, 0%, 100%, .1)
+}
+
+.swagger-ui .bg-black {
+  background-color: #000
+}
+
+.swagger-ui .bg-near-black {
+  background-color: #111
+}
+
+.swagger-ui .bg-dark-gray {
+  background-color: #333
+}
+
+.swagger-ui .bg-mid-gray {
+  background-color: #555
+}
+
+.swagger-ui .bg-gray {
+  background-color: #777
+}
+
+.swagger-ui .bg-silver {
+  background-color: #999
+}
+
+.swagger-ui .bg-light-silver {
+  background-color: #aaa
+}
+
+.swagger-ui .bg-moon-gray {
+  background-color: #ccc
+}
+
+.swagger-ui .bg-light-gray {
+  background-color: #eee
+}
+
+.swagger-ui .bg-near-white {
+  background-color: #f4f4f4
+}
+
+.swagger-ui .bg-white {
+  background-color: #fff
+}
+
+.swagger-ui .bg-transparent {
+  background-color: transparent
+}
+
+.swagger-ui .bg-dark-red {
+  background-color: #e7040f
+}
+
+.swagger-ui .bg-red {
+  background-color: #ff4136
+}
+
+.swagger-ui .bg-light-red {
+  background-color: #ff725c
+}
+
+.swagger-ui .bg-orange {
+  background-color: #ff6300
+}
+
+.swagger-ui .bg-gold {
+  background-color: #ffb700
+}
+
+.swagger-ui .bg-yellow {
+  background-color: gold
+}
+
+.swagger-ui .bg-light-yellow {
+  background-color: #fbf1a9
+}
+
+.swagger-ui .bg-purple {
+  background-color: #5e2ca5
+}
+
+.swagger-ui .bg-light-purple {
+  background-color: #a463f2
+}
+
+.swagger-ui .bg-dark-pink {
+  background-color: #d5008f
+}
+
+.swagger-ui .bg-hot-pink {
+  background-color: #ff41b4
+}
+
+.swagger-ui .bg-pink {
+  background-color: #ff80cc
+}
+
+.swagger-ui .bg-light-pink {
+  background-color: #ffa3d7
+}
+
+.swagger-ui .bg-dark-green {
+  background-color: #137752
+}
+
+.swagger-ui .bg-green {
+  background-color: #19a974
+}
+
+.swagger-ui .bg-light-green {
+  background-color: #9eebcf
+}
+
+.swagger-ui .bg-navy {
+  background-color: #001b44
+}
+
+.swagger-ui .bg-dark-blue {
+  background-color: #00449e
+}
+
+.swagger-ui .bg-blue {
+  background-color: #357edd
+}
+
+.swagger-ui .bg-light-blue {
+  background-color: #96ccff
+}
+
+.swagger-ui .bg-lightest-blue {
+  background-color: #cdecff
+}
+
+.swagger-ui .bg-washed-blue {
+  background-color: #f6fffe
+}
+
+.swagger-ui .bg-washed-green {
+  background-color: #e8fdf5
+}
+
+.swagger-ui .bg-washed-yellow {
+  background-color: #fffceb
+}
+
+.swagger-ui .bg-washed-red {
+  background-color: #ffdfdf
+}
+
+.swagger-ui .hover-black:focus,
+.swagger-ui .hover-black:hover {
+  color: #000
+}
+
+.swagger-ui .hover-near-black:focus,
+.swagger-ui .hover-near-black:hover {
+  color: #111
+}
+
+.swagger-ui .hover-dark-gray:focus,
+.swagger-ui .hover-dark-gray:hover {
+  color: #333
+}
+
+.swagger-ui .hover-mid-gray:focus,
+.swagger-ui .hover-mid-gray:hover {
+  color: #555
+}
+
+.swagger-ui .hover-gray:focus,
+.swagger-ui .hover-gray:hover {
+  color: #777
+}
+
+.swagger-ui .hover-silver:focus,
+.swagger-ui .hover-silver:hover {
+  color: #999
+}
+
+.swagger-ui .hover-light-silver:focus,
+.swagger-ui .hover-light-silver:hover {
+  color: #aaa
+}
+
+.swagger-ui .hover-moon-gray:focus,
+.swagger-ui .hover-moon-gray:hover {
+  color: #ccc
+}
+
+.swagger-ui .hover-light-gray:focus,
+.swagger-ui .hover-light-gray:hover {
+  color: #eee
+}
+
+.swagger-ui .hover-near-white:focus,
+.swagger-ui .hover-near-white:hover {
+  color: #f4f4f4
+}
+
+.swagger-ui .hover-white:focus,
+.swagger-ui .hover-white:hover {
+  color: #fff
+}
+
+.swagger-ui .hover-black-90:focus,
+.swagger-ui .hover-black-90:hover {
+  color: rgba(0, 0, 0, .9)
+}
+
+.swagger-ui .hover-black-80:focus,
+.swagger-ui .hover-black-80:hover {
+  color: rgba(0, 0, 0, .8)
+}
+
+.swagger-ui .hover-black-70:focus,
+.swagger-ui .hover-black-70:hover {
+  color: rgba(0, 0, 0, .7)
+}
+
+.swagger-ui .hover-black-60:focus,
+.swagger-ui .hover-black-60:hover {
+  color: rgba(0, 0, 0, .6)
+}
+
+.swagger-ui .hover-black-50:focus,
+.swagger-ui .hover-black-50:hover {
+  color: rgba(0, 0, 0, .5)
+}
+
+.swagger-ui .hover-black-40:focus,
+.swagger-ui .hover-black-40:hover {
+  color: rgba(0, 0, 0, .4)
+}
+
+.swagger-ui .hover-black-30:focus,
+.swagger-ui .hover-black-30:hover {
+  color: rgba(0, 0, 0, .3)
+}
+
+.swagger-ui .hover-black-20:focus,
+.swagger-ui .hover-black-20:hover {
+  color: rgba(0, 0, 0, .2)
+}
+
+.swagger-ui .hover-black-10:focus,
+.swagger-ui .hover-black-10:hover {
+  color: rgba(0, 0, 0, .1)
+}
+
+.swagger-ui .hover-white-90:focus,
+.swagger-ui .hover-white-90:hover {
+  color: hsla(0, 0%, 100%, .9)
+}
+
+.swagger-ui .hover-white-80:focus,
+.swagger-ui .hover-white-80:hover {
+  color: hsla(0, 0%, 100%, .8)
+}
+
+.swagger-ui .hover-white-70:focus,
+.swagger-ui .hover-white-70:hover {
+  color: hsla(0, 0%, 100%, .7)
+}
+
+.swagger-ui .hover-white-60:focus,
+.swagger-ui .hover-white-60:hover {
+  color: hsla(0, 0%, 100%, .6)
+}
+
+.swagger-ui .hover-white-50:focus,
+.swagger-ui .hover-white-50:hover {
+  color: hsla(0, 0%, 100%, .5)
+}
+
+.swagger-ui .hover-white-40:focus,
+.swagger-ui .hover-white-40:hover {
+  color: hsla(0, 0%, 100%, .4)
+}
+
+.swagger-ui .hover-white-30:focus,
+.swagger-ui .hover-white-30:hover {
+  color: hsla(0, 0%, 100%, .3)
+}
+
+.swagger-ui .hover-white-20:focus,
+.swagger-ui .hover-white-20:hover {
+  color: hsla(0, 0%, 100%, .2)
+}
+
+.swagger-ui .hover-white-10:focus,
+.swagger-ui .hover-white-10:hover {
+  color: hsla(0, 0%, 100%, .1)
+}
+
+.swagger-ui .hover-inherit:focus,
+.swagger-ui .hover-inherit:hover {
+  color: inherit
+}
+
+.swagger-ui .hover-bg-black:focus,
+.swagger-ui .hover-bg-black:hover {
+  background-color: #000
+}
+
+.swagger-ui .hover-bg-near-black:focus,
+.swagger-ui .hover-bg-near-black:hover {
+  background-color: #111
+}
+
+.swagger-ui .hover-bg-dark-gray:focus,
+.swagger-ui .hover-bg-dark-gray:hover {
+  background-color: #333
+}
+
+.swagger-ui .hover-bg-mid-gray:focus,
+.swagger-ui .hover-bg-mid-gray:hover {
+  background-color: #555
+}
+
+.swagger-ui .hover-bg-gray:focus,
+.swagger-ui .hover-bg-gray:hover {
+  background-color: #777
+}
+
+.swagger-ui .hover-bg-silver:focus,
+.swagger-ui .hover-bg-silver:hover {
+  background-color: #999
+}
+
+.swagger-ui .hover-bg-light-silver:focus,
+.swagger-ui .hover-bg-light-silver:hover {
+  background-color: #aaa
+}
+
+.swagger-ui .hover-bg-moon-gray:focus,
+.swagger-ui .hover-bg-moon-gray:hover {
+  background-color: #ccc
+}
+
+.swagger-ui .hover-bg-light-gray:focus,
+.swagger-ui .hover-bg-light-gray:hover {
+  background-color: #eee
+}
+
+.swagger-ui .hover-bg-near-white:focus,
+.swagger-ui .hover-bg-near-white:hover {
+  background-color: #f4f4f4
+}
+
+.swagger-ui .hover-bg-white:focus,
+.swagger-ui .hover-bg-white:hover {
+  background-color: #fff
+}
+
+.swagger-ui .hover-bg-transparent:focus,
+.swagger-ui .hover-bg-transparent:hover {
+  background-color: transparent
+}
+
+.swagger-ui .hover-bg-black-90:focus,
+.swagger-ui .hover-bg-black-90:hover {
+  background-color: rgba(0, 0, 0, .9)
+}
+
+.swagger-ui .hover-bg-black-80:focus,
+.swagger-ui .hover-bg-black-80:hover {
+  background-color: rgba(0, 0, 0, .8)
+}
+
+.swagger-ui .hover-bg-black-70:focus,
+.swagger-ui .hover-bg-black-70:hover {
+  background-color: rgba(0, 0, 0, .7)
+}
+
+.swagger-ui .hover-bg-black-60:focus,
+.swagger-ui .hover-bg-black-60:hover {
+  background-color: rgba(0, 0, 0, .6)
+}
+
+.swagger-ui .hover-bg-black-50:focus,
+.swagger-ui .hover-bg-black-50:hover {
+  background-color: rgba(0, 0, 0, .5)
+}
+
+.swagger-ui .hover-bg-black-40:focus,
+.swagger-ui .hover-bg-black-40:hover {
+  background-color: rgba(0, 0, 0, .4)
+}
+
+.swagger-ui .hover-bg-black-30:focus,
+.swagger-ui .hover-bg-black-30:hover {
+  background-color: rgba(0, 0, 0, .3)
+}
+
+.swagger-ui .hover-bg-black-20:focus,
+.swagger-ui .hover-bg-black-20:hover {
+  background-color: rgba(0, 0, 0, .2)
+}
+
+.swagger-ui .hover-bg-black-10:focus,
+.swagger-ui .hover-bg-black-10:hover {
+  background-color: rgba(0, 0, 0, .1)
+}
+
+.swagger-ui .hover-bg-white-90:focus,
+.swagger-ui .hover-bg-white-90:hover {
+  background-color: hsla(0, 0%, 100%, .9)
+}
+
+.swagger-ui .hover-bg-white-80:focus,
+.swagger-ui .hover-bg-white-80:hover {
+  background-color: hsla(0, 0%, 100%, .8)
+}
+
+.swagger-ui .hover-bg-white-70:focus,
+.swagger-ui .hover-bg-white-70:hover {
+  background-color: hsla(0, 0%, 100%, .7)
+}
+
+.swagger-ui .hover-bg-white-60:focus,
+.swagger-ui .hover-bg-white-60:hover {
+  background-color: hsla(0, 0%, 100%, .6)
+}
+
+.swagger-ui .hover-bg-white-50:focus,
+.swagger-ui .hover-bg-white-50:hover {
+  background-color: hsla(0, 0%, 100%, .5)
+}
+
+.swagger-ui .hover-bg-white-40:focus,
+.swagger-ui .hover-bg-white-40:hover {
+  background-color: hsla(0, 0%, 100%, .4)
+}
+
+.swagger-ui .hover-bg-white-30:focus,
+.swagger-ui .hover-bg-white-30:hover {
+  background-color: hsla(0, 0%, 100%, .3)
+}
+
+.swagger-ui .hover-bg-white-20:focus,
+.swagger-ui .hover-bg-white-20:hover {
+  background-color: hsla(0, 0%, 100%, .2)
+}
+
+.swagger-ui .hover-bg-white-10:focus,
+.swagger-ui .hover-bg-white-10:hover {
+  background-color: hsla(0, 0%, 100%, .1)
+}
+
+.swagger-ui .hover-dark-red:focus,
+.swagger-ui .hover-dark-red:hover {
+  color: #e7040f
+}
+
+.swagger-ui .hover-red:focus,
+.swagger-ui .hover-red:hover {
+  color: #ff4136
+}
+
+.swagger-ui .hover-light-red:focus,
+.swagger-ui .hover-light-red:hover {
+  color: #ff725c
+}
+
+.swagger-ui .hover-orange:focus,
+.swagger-ui .hover-orange:hover {
+  color: #ff6300
+}
+
+.swagger-ui .hover-gold:focus,
+.swagger-ui .hover-gold:hover {
+  color: #ffb700
+}
+
+.swagger-ui .hover-yellow:focus,
+.swagger-ui .hover-yellow:hover {
+  color: gold
+}
+
+.swagger-ui .hover-light-yellow:focus,
+.swagger-ui .hover-light-yellow:hover {
+  color: #fbf1a9
+}
+
+.swagger-ui .hover-purple:focus,
+.swagger-ui .hover-purple:hover {
+  color: #5e2ca5
+}
+
+.swagger-ui .hover-light-purple:focus,
+.swagger-ui .hover-light-purple:hover {
+  color: #a463f2
+}
+
+.swagger-ui .hover-dark-pink:focus,
+.swagger-ui .hover-dark-pink:hover {
+  color: #d5008f
+}
+
+.swagger-ui .hover-hot-pink:focus,
+.swagger-ui .hover-hot-pink:hover {
+  color: #ff41b4
+}
+
+.swagger-ui .hover-pink:focus,
+.swagger-ui .hover-pink:hover {
+  color: #ff80cc
+}
+
+.swagger-ui .hover-light-pink:focus,
+.swagger-ui .hover-light-pink:hover {
+  color: #ffa3d7
+}
+
+.swagger-ui .hover-dark-green:focus,
+.swagger-ui .hover-dark-green:hover {
+  color: #137752
+}
+
+.swagger-ui .hover-green:focus,
+.swagger-ui .hover-green:hover {
+  color: #19a974
+}
+
+.swagger-ui .hover-light-green:focus,
+.swagger-ui .hover-light-green:hover {
+  color: #9eebcf
+}
+
+.swagger-ui .hover-navy:focus,
+.swagger-ui .hover-navy:hover {
+  color: #001b44
+}
+
+.swagger-ui .hover-dark-blue:focus,
+.swagger-ui .hover-dark-blue:hover {
+  color: #00449e
+}
+
+.swagger-ui .hover-blue:focus,
+.swagger-ui .hover-blue:hover {
+  color: #357edd
+}
+
+.swagger-ui .hover-light-blue:focus,
+.swagger-ui .hover-light-blue:hover {
+  color: #96ccff
+}
+
+.swagger-ui .hover-lightest-blue:focus,
+.swagger-ui .hover-lightest-blue:hover {
+  color: #cdecff
+}
+
+.swagger-ui .hover-washed-blue:focus,
+.swagger-ui .hover-washed-blue:hover {
+  color: #f6fffe
+}
+
+.swagger-ui .hover-washed-green:focus,
+.swagger-ui .hover-washed-green:hover {
+  color: #e8fdf5
+}
+
+.swagger-ui .hover-washed-yellow:focus,
+.swagger-ui .hover-washed-yellow:hover {
+  color: #fffceb
+}
+
+.swagger-ui .hover-washed-red:focus,
+.swagger-ui .hover-washed-red:hover {
+  color: #ffdfdf
+}
+
+.swagger-ui .hover-bg-dark-red:focus,
+.swagger-ui .hover-bg-dark-red:hover {
+  background-color: #e7040f
+}
+
+.swagger-ui .hover-bg-red:focus,
+.swagger-ui .hover-bg-red:hover {
+  background-color: #ff4136
+}
+
+.swagger-ui .hover-bg-light-red:focus,
+.swagger-ui .hover-bg-light-red:hover {
+  background-color: #ff725c
+}
+
+.swagger-ui .hover-bg-orange:focus,
+.swagger-ui .hover-bg-orange:hover {
+  background-color: #ff6300
+}
+
+.swagger-ui .hover-bg-gold:focus,
+.swagger-ui .hover-bg-gold:hover {
+  background-color: #ffb700
+}
+
+.swagger-ui .hover-bg-yellow:focus,
+.swagger-ui .hover-bg-yellow:hover {
+  background-color: gold
+}
+
+.swagger-ui .hover-bg-light-yellow:focus,
+.swagger-ui .hover-bg-light-yellow:hover {
+  background-color: #fbf1a9
+}
+
+.swagger-ui .hover-bg-purple:focus,
+.swagger-ui .hover-bg-purple:hover {
+  background-color: #5e2ca5
+}
+
+.swagger-ui .hover-bg-light-purple:focus,
+.swagger-ui .hover-bg-light-purple:hover {
+  background-color: #a463f2
+}
+
+.swagger-ui .hover-bg-dark-pink:focus,
+.swagger-ui .hover-bg-dark-pink:hover {
+  background-color: #d5008f
+}
+
+.swagger-ui .hover-bg-hot-pink:focus,
+.swagger-ui .hover-bg-hot-pink:hover {
+  background-color: #ff41b4
+}
+
+.swagger-ui .hover-bg-pink:focus,
+.swagger-ui .hover-bg-pink:hover {
+  background-color: #ff80cc
+}
+
+.swagger-ui .hover-bg-light-pink:focus,
+.swagger-ui .hover-bg-light-pink:hover {
+  background-color: #ffa3d7
+}
+
+.swagger-ui .hover-bg-dark-green:focus,
+.swagger-ui .hover-bg-dark-green:hover {
+  background-color: #137752
+}
+
+.swagger-ui .hover-bg-green:focus,
+.swagger-ui .hover-bg-green:hover {
+  background-color: #19a974
+}
+
+.swagger-ui .hover-bg-light-green:focus,
+.swagger-ui .hover-bg-light-green:hover {
+  background-color: #9eebcf
+}
+
+.swagger-ui .hover-bg-navy:focus,
+.swagger-ui .hover-bg-navy:hover {
+  background-color: #001b44
+}
+
+.swagger-ui .hover-bg-dark-blue:focus,
+.swagger-ui .hover-bg-dark-blue:hover {
+  background-color: #00449e
+}
+
+.swagger-ui .hover-bg-blue:focus,
+.swagger-ui .hover-bg-blue:hover {
+  background-color: #357edd
+}
+
+.swagger-ui .hover-bg-light-blue:focus,
+.swagger-ui .hover-bg-light-blue:hover {
+  background-color: #96ccff
+}
+
+.swagger-ui .hover-bg-lightest-blue:focus,
+.swagger-ui .hover-bg-lightest-blue:hover {
+  background-color: #cdecff
+}
+
+.swagger-ui .hover-bg-washed-blue:focus,
+.swagger-ui .hover-bg-washed-blue:hover {
+  background-color: #f6fffe
+}
+
+.swagger-ui .hover-bg-washed-green:focus,
+.swagger-ui .hover-bg-washed-green:hover {
+  background-color: #e8fdf5
+}
+
+.swagger-ui .hover-bg-washed-yellow:focus,
+.swagger-ui .hover-bg-washed-yellow:hover {
+  background-color: #fffceb
+}
+
+.swagger-ui .hover-bg-washed-red:focus,
+.swagger-ui .hover-bg-washed-red:hover {
+  background-color: #ffdfdf
+}
+
+.swagger-ui .hover-bg-inherit:focus,
+.swagger-ui .hover-bg-inherit:hover {
+  background-color: inherit
+}
+
+.swagger-ui .striped--light-silver:nth-child(odd) {
+  background-color: #aaa
+}
+
+.swagger-ui .striped--moon-gray:nth-child(odd) {
+  background-color: #ccc
+}
+
+.swagger-ui .striped--light-gray:nth-child(odd) {
+  background-color: #eee
+}
+
+.swagger-ui .striped--near-white:nth-child(odd) {
+  background-color: #f4f4f4
+}
+
+.swagger-ui .stripe-light:nth-child(odd) {
+  background-color: hsla(0, 0%, 100%, .1)
+}
+
+.swagger-ui .stripe-dark:nth-child(odd) {
+  background-color: rgba(0, 0, 0, .1)
+}
+
+.swagger-ui .nested-links a {
+  color: #357edd;
+}
+
+.swagger-ui .nested-links a:focus,
+.swagger-ui .nested-links a:hover {
+  color: #96ccff;
+}
+
+.swagger-ui .opblock-tag {
+  border-bottom: 1px solid rgba(59, 65, 81, .3)
+}
+
+.swagger-ui .opblock-tag:hover {
+  background: rgba(0, 0, 0, .02)
+}
+
+.swagger-ui .opblock-tag {
+  color: #3b4151
+}
+
+.swagger-ui .opblock-tag small {
+  color: #3b4151
+}
+
+.swagger-ui .parameter__type {
+  color: #3b4151
+}
+
+.swagger-ui .opblock {
+  border: 1px solid #000;
+  box-shadow: 0 0 3px rgba(0, 0, 0, .19)
+}
+
+.swagger-ui .opblock .tab-header .tab-item.active h4 span:after {
+  background: grey
+}
+
+.swagger-ui .opblock.is-open .opblock-summary {
+  border-bottom: 1px solid #000
+}
+
+.swagger-ui .opblock .opblock-section-header {
+  background: hsla(0, 0%, 100%, .8);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .1)
+}
+
+.swagger-ui .opblock .opblock-section-header>label {
+  color: #3b4151
+}
+
+.swagger-ui .opblock .opblock-section-header h4 {
+  color: #3b4151
+}
+
+.swagger-ui .opblock .opblock-summary-method {
+  background: #000;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, .1);
+  color: #fff
+}
+
+.swagger-ui .opblock .opblock-summary-operation-id,
+.swagger-ui .opblock .opblock-summary-path,
+.swagger-ui .opblock .opblock-summary-path__deprecated {
+  color: #3b4151
+}
+
+.swagger-ui .opblock .opblock-summary-description {
+  color: #3b4151
+}
+
+.swagger-ui .opblock.opblock-post {
+  border-color: #49cc90;
+  background: rgba(73, 204, 144, .1)
+}
+
+.swagger-ui .opblock.opblock-post .opblock-summary-method {
+  background: #49cc90
+}
+
+.swagger-ui .opblock.opblock-post .opblock-summary {
+  border-color: #49cc90
+}
+
+.swagger-ui .opblock.opblock-post .tab-header .tab-item.active h4 span:after {
+  background: #49cc90
+}
+
+.swagger-ui .opblock.opblock-put {
+  border-color: #fca130;
+  background: rgba(252, 161, 48, .1)
+}
+
+.swagger-ui .opblock.opblock-put .opblock-summary-method {
+  background: #fca130
+}
+
+.swagger-ui .opblock.opblock-put .opblock-summary {
+  border-color: #fca130
+}
+
+.swagger-ui .opblock.opblock-put .tab-header .tab-item.active h4 span:after {
+  background: #fca130
+}
+
+.swagger-ui .opblock.opblock-delete {
+  border-color: #f93e3e;
+  background: rgba(249, 62, 62, .1)
+}
+
+.swagger-ui .opblock.opblock-delete .opblock-summary-method {
+  background: #f93e3e
+}
+
+.swagger-ui .opblock.opblock-delete .opblock-summary {
+  border-color: #f93e3e
+}
+
+.swagger-ui .opblock.opblock-delete .tab-header .tab-item.active h4 span:after {
+  background: #f93e3e
+}
+
+.swagger-ui .opblock.opblock-get {
+  border-color: #61affe;
+  background: rgba(97, 175, 254, .1)
+}
+
+.swagger-ui .opblock.opblock-get .opblock-summary-method {
+  background: #61affe
+}
+
+.swagger-ui .opblock.opblock-get .opblock-summary {
+  border-color: #61affe
+}
+
+.swagger-ui .opblock.opblock-get .tab-header .tab-item.active h4 span:after {
+  background: #61affe
+}
+
+.swagger-ui .opblock.opblock-patch {
+  border-color: #50e3c2;
+  background: rgba(80, 227, 194, .1)
+}
+
+.swagger-ui .opblock.opblock-patch .opblock-summary-method {
+  background: #50e3c2
+}
+
+.swagger-ui .opblock.opblock-patch .opblock-summary {
+  border-color: #50e3c2
+}
+
+.swagger-ui .opblock.opblock-patch .tab-header .tab-item.active h4 span:after {
+  background: #50e3c2
+}
+
+.swagger-ui .opblock.opblock-head {
+  border-color: #9012fe;
+  background: rgba(144, 18, 254, .1)
+}
+
+.swagger-ui .opblock.opblock-head .opblock-summary-method {
+  background: #9012fe
+}
+
+.swagger-ui .opblock.opblock-head .opblock-summary {
+  border-color: #9012fe
+}
+
+.swagger-ui .opblock.opblock-head .tab-header .tab-item.active h4 span:after {
+  background: #9012fe
+}
+
+.swagger-ui .opblock.opblock-options {
+  border-color: #0d5aa7;
+  background: rgba(13, 90, 167, .1)
+}
+
+.swagger-ui .opblock.opblock-options .opblock-summary-method {
+  background: #0d5aa7
+}
+
+.swagger-ui .opblock.opblock-options .opblock-summary {
+  border-color: #0d5aa7
+}
+
+.swagger-ui .opblock.opblock-options .tab-header .tab-item.active h4 span:after {
+  background: #0d5aa7
+}
+
+.swagger-ui .opblock.opblock-deprecated {
+  border-color: #ebebeb;
+  background: hsla(0, 0%, 92.2%, .1)
+}
+
+.swagger-ui .opblock.opblock-deprecated .opblock-summary-method {
+  background: #ebebeb
+}
+
+.swagger-ui .opblock.opblock-deprecated .opblock-summary {
+  border-color: #ebebeb
+}
+
+.swagger-ui .opblock.opblock-deprecated .tab-header .tab-item.active h4 span:after {
+  background: #ebebeb
+}
+
+.swagger-ui .filter .operation-filter-input {
+  border: 2px solid #d8dde7
+}
+
+.swagger-ui .download-url-wrapper .failed,
+.swagger-ui .filter .failed {
+  color: red
+}
+
+.swagger-ui .download-url-wrapper .loading,
+.swagger-ui .filter .loading {
+  color: #aaa
+}
+
+.swagger-ui .tab li {
+  color: #3b4151
+}
+
+.swagger-ui .tab li:first-of-type:after {
+  background: rgba(0, 0, 0, .2)
+}
+
+.swagger-ui .opblock-description-wrapper,
+.swagger-ui .opblock-external-docs-wrapper,
+.swagger-ui .opblock-title_normal {
+  color: #3b4151
+}
+
+.swagger-ui .opblock-description-wrapper h4,
+.swagger-ui .opblock-external-docs-wrapper h4,
+.swagger-ui .opblock-title_normal h4 {
+  color: #3b4151
+}
+
+.swagger-ui .opblock-description-wrapper p,
+.swagger-ui .opblock-external-docs-wrapper p,
+.swagger-ui .opblock-title_normal p {
+  color: #3b4151
+}
+
+.swagger-ui .responses-inner h4,
+.swagger-ui .responses-inner h5 {
+  color: #3b4151
+}
+
+.swagger-ui .response-col_status {
+  color: #3b4151
+}
+
+.swagger-ui .response-col_status .response-undocumented {
+  color: #909090
+}
+
+.swagger-ui .response-col_links {
+  color: #3b4151
+}
+
+.swagger-ui .response-col_links .response-undocumented {
+  color: #909090
+}
+
+.swagger-ui .opblock-body pre.microlight {
+  background: #333;
+  color: #fff
+}
+
+.swagger-ui .download-contents {
+  background: #7d8293;
+  color: #fff;
+}
+
+.swagger-ui .scheme-container {
+  background: #fff;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, .15)
+}
+
+.swagger-ui .scheme-container .schemes>label {
+  color: #3b4151
+}
+
+.swagger-ui .loading-container .loading:after {
+  color: #3b4151
+}
+
+.swagger-ui .loading-container .loading:before {
+  border: 2px solid rgba(85, 85, 85, .1);
+  border-top-color: rgba(0, 0, 0, .6);
+}
+
+.swagger-ui .response-control-media-type--accept-controller select {
+  border-color: green
+}
+
+.swagger-ui .response-control-media-type__accept-message {
+  color: green;
+}
+
+.swagger-ui section h3 {
+  color: #3b4151
+}
+
+.swagger-ui .fallback {
+  color: #aaa
+}
+
+.swagger-ui .version-pragma__message code {
+  background-color: #dedede;
+}
+
+.swagger-ui span.token-string {
+  color: #555
+}
+
+.swagger-ui span.token-not-formatted {
+  color: #555;
+}
+
+.swagger-ui .btn {
+  border: 2px solid grey;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .1);
+  color: #3b4151
+}
+
+.swagger-ui .btn:hover {
+  box-shadow: 0 0 5px rgba(0, 0, 0, .3)
+}
+
+.swagger-ui .btn.cancel {
+  border-color: #ff6060;
+  background-color: transparent;
+  color: #ff6060
+}
+
+.swagger-ui .btn.authorize {
+  color: #49cc90;
+  border-color: #49cc90;
+}
+
+.swagger-ui .btn.authorize svg {
+  fill: #49cc90
+}
+
+.swagger-ui .btn.execute {
+  background-color: #4990e2;
+  color: #fff;
+  border-color: #4990e2
+}
+
+.swagger-ui .expand-methods:hover svg {
+  fill: #404040
+}
+
+.swagger-ui .expand-methods svg {
+  fill: #707070
+}
+
+.swagger-ui button.invalid {
+  border-color: #f93e3e;
+  background: #feebeb
+}
+
+.swagger-ui .copy-to-clipboard {
+  background: #7d8293;
+}
+
+.swagger-ui .copy-to-clipboard button {
+  background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" aria-hidden="true"><path fill="%23fff" fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"/></svg>') 50% no-repeat
+}
+
+.swagger-ui select {
+  border: 2px solid #41444e;
+  background: #f7f7f7 url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M13.418 7.859a.695.695 0 01.978 0 .68.68 0 010 .969l-3.908 3.83a.697.697 0 01-.979 0l-3.908-3.83a.68.68 0 010-.969.695.695 0 01.978 0L10 11l3.418-3.141z"/></svg>') right 10px center no-repeat;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, .25);
+  color: #3b4151;
+}
+
+.swagger-ui select[multiple] {
+  background: #f7f7f7
+}
+
+.swagger-ui select.invalid {
+  border-color: #f93e3e;
+  background: #feebeb
+}
+
+.swagger-ui label {
+  color: #3b4151
+}
+
+.swagger-ui input[type=email],
+.swagger-ui input[type=file],
+.swagger-ui input[type=password],
+.swagger-ui input[type=search],
+.swagger-ui input[type=text],
+.swagger-ui textarea {
+  border: 1px solid #d9d9d9;
+  background: #fff
+}
+
+.swagger-ui input[type=email].invalid,
+.swagger-ui input[type=file].invalid,
+.swagger-ui input[type=password].invalid,
+.swagger-ui input[type=search].invalid,
+.swagger-ui input[type=text].invalid,
+.swagger-ui textarea.invalid {
+  border-color: #f93e3e;
+  background: #feebeb
+}
+
+.swagger-ui input[disabled],
+.swagger-ui select[disabled],
+.swagger-ui textarea[disabled] {
+  background-color: #fafafa;
+  color: #888;
+}
+
+.swagger-ui select[disabled] {
+  border-color: #888
+}
+
+.swagger-ui textarea[disabled] {
+  background-color: #41444e;
+  color: #fff
+}
+
+.swagger-ui textarea {
+  background: hsla(0, 0%, 100%, .8);
+  color: #3b4151
+}
+
+.swagger-ui textarea:focus {
+  border: 2px solid #61affe
+}
+
+.swagger-ui textarea.curl {
+  background: #41444e;
+  color: #fff
+}
+
+.swagger-ui .checkbox {
+  color: #303030
+}
+
+.swagger-ui .checkbox p {
+  color: #3b4151
+}
+
+.swagger-ui .checkbox input[type=checkbox]+label>.item {
+  background: #e8e8e8;
+  box-shadow: 0 0 0 2px #e8e8e8;
+}
+
+.swagger-ui .checkbox input[type=checkbox]:checked+label>.item {
+  background: #e8e8e8 url('data:image/svg+xml;charset=utf-8,<svg width="10" height="8" viewBox="3 7 10 8" xmlns="http://www.w3.org/2000/svg"><path fill="%2341474E" fill-rule="evenodd" d="M6.333 15L3 11.667l1.333-1.334 2 2L11.667 7 13 8.333z"/></svg>') 50% no-repeat
+}
+
+.swagger-ui .dialog-ux .backdrop-ux {
+  background: rgba(0, 0, 0, .8)
+}
+
+.swagger-ui .dialog-ux .modal-ux {
+  border: 1px solid #ebebeb;
+  background: #fff;
+  box-shadow: 0 10px 30px 0 rgba(0, 0, 0, .2)
+}
+
+.swagger-ui .dialog-ux .modal-ux-content p {
+  color: #3b4151
+}
+
+.swagger-ui .dialog-ux .modal-ux-content h4 {
+  color: #3b4151
+}
+
+.swagger-ui .dialog-ux .modal-ux-header {
+  border-bottom: 1px solid #ebebeb;
+}
+
+.swagger-ui .dialog-ux .modal-ux-header h3 {
+  color: #3b4151
+}
+
+.swagger-ui .model {
+  color: #3b4151
+}
+
+.swagger-ui .model .deprecated span,
+.swagger-ui .model .deprecated td {
+  color: #a0a0a0!important
+}
+
+.swagger-ui .model-toggle:after {
+  background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>') 50% no-repeat;
+}
+
+.swagger-ui .model-hint {
+  color: #ebebeb;
+  background: rgba(0, 0, 0, .7)
+}
+
+.swagger-ui .model .property {
+  color: #999;
+}
+
+.swagger-ui .model .property.primitive {
+  color: #6b6b6b
+}
+
+.swagger-ui table.model tr.description {
+  color: #666;
+}
+
+.swagger-ui table.model tr.property-row .star {
+  color: red
+}
+
+.swagger-ui table.model tr.extension {
+  color: #777
+}
+
+.swagger-ui section.models {
+  border: 1px solid rgba(59, 65, 81, .3);
+}
+
+.swagger-ui section.models.is-open h4 {
+  border-bottom: 1px solid rgba(59, 65, 81, .3)
+}
+
+.swagger-ui section.models h4 {
+  color: #606060
+}
+
+.swagger-ui section.models h4:hover {
+  background: rgba(0, 0, 0, .02)
+}
+
+.swagger-ui section.models h5 {
+  color: #707070
+}
+
+.swagger-ui section.models .model-container {
+  background: rgba(0, 0, 0, .05)
+}
+
+.swagger-ui section.models .model-container:hover {
+  background: rgba(0, 0, 0, .07)
+}
+
+.swagger-ui .model-box {
+  background: rgba(0, 0, 0, .1)
+}
+
+.swagger-ui .model-title {
+  color: #505050
+}
+
+.swagger-ui .model-deprecated-warning {
+  color: #f93e3e
+}
+
+.swagger-ui .prop-type {
+  color: #55a
+}
+
+.swagger-ui .prop-format {
+  color: #606060
+}
+
+.swagger-ui .servers>label {
+  color: #3b4151
+}
+
+.swagger-ui table.headers td {
+  color: #3b4151
+}
+
+.swagger-ui table.headers .header-example {
+  color: #999;
+}
+
+.swagger-ui table thead tr td,
+.swagger-ui table thead tr th {
+  border-bottom: 1px solid rgba(59, 65, 81, .2);
+  color: #3b4151
+}
+
+.swagger-ui .parameter__name {
+  color: #3b4151
+}
+
+.swagger-ui .parameter__name.required span {
+  color: red
+}
+
+.swagger-ui .parameter__name.required:after {
+  color: rgba(255, 0, 0, .6)
+}
+
+.swagger-ui .parameter__extension,
+.swagger-ui .parameter__in {
+  color: grey
+}
+
+.swagger-ui .parameter__deprecated {
+  color: red
+}
+
+.swagger-ui .response__extension {
+  color: grey
+}
+
+.swagger-ui .topbar {
+  background-color: #1b1b1b
+}
+
+.swagger-ui .topbar a {
+  color: #fff
+}
+
+.swagger-ui .topbar .download-url-wrapper input[type=text] {
+  border: 2px solid #62a03f;
+}
+
+.swagger-ui .topbar .download-url-wrapper .select-label {
+  color: #f0f0f0
+}
+
+.swagger-ui .topbar .download-url-wrapper .select-label select {
+  border: 2px solid #62a03f;
+}
+
+.swagger-ui .topbar .download-url-wrapper .download-url-button {
+  background: #62a03f;
+  color: #fff
+}
+
+.swagger-ui .info li,
+.swagger-ui .info p,
+.swagger-ui .info table {
+  color: #3b4151
+}
+
+.swagger-ui .info h1,
+.swagger-ui .info h2,
+.swagger-ui .info h3,
+.swagger-ui .info h4,
+.swagger-ui .info h5 {
+  color: #3b4151
+}
+
+.swagger-ui .info a {
+  color: #4990e2
+}
+
+.swagger-ui .info a:hover {
+  color: #1f69c0
+}
+
+.swagger-ui .info .base-url {
+  color: #3b4151
+}
+
+.swagger-ui .info .title {
+  color: #3b4151
+}
+
+.swagger-ui .info .title small {
+  background: #7d8492
+}
+
+.swagger-ui .info .title small.version-stamp {
+  background-color: #89bf04
+}
+
+.swagger-ui .info .title small pre {
+  color: #fff
+}
+
+.swagger-ui .auth-container {
+  border-bottom: 1px solid #ebebeb
+}
+
+.swagger-ui .auth-container .errors {
+  background-color: #fee;
+  color: #3b4151
+}
+
+.swagger-ui .scopes h2 {
+  color: #3b4151
+}
+
+.swagger-ui .scopes h2 a {
+  color: #4990e2;
+}
+
+.swagger-ui .errors-wrapper {
+  border: 2px solid #f93e3e;
+  background: rgba(249, 62, 62, .1)
+}
+
+.swagger-ui .errors-wrapper .errors h4 {
+  color: #3b4151
+}
+
+.swagger-ui .errors-wrapper .errors small {
+  color: #606060
+}
+
+.swagger-ui .errors-wrapper hgroup h4 {
+  color: #3b4151
+}
+
+.swagger-ui .markdown pre,
+.swagger-ui .renderedMarkdown pre {
+  color: #000;
+}
+
+.swagger-ui .markdown code,
+.swagger-ui .renderedMarkdown code {
+  background: rgba(0, 0, 0, .05);
+  color: #9012fe
+}

--- a/src/main/js/swaggerUIColors.css
+++ b/src/main/js/swaggerUIColors.css
@@ -1,1425 +1,74 @@
+/* TODO: Remove css vars! Only for test purpose! */
 .swagger-ui {
-  color: #3b4151
-}
-
-.swagger-ui mark {
-  background-color: #ff0;
-  color: #000
-}
-
-.swagger-ui .debug * {
-  outline: 1px solid gold
-}
-
-.swagger-ui .debug-white * {
-  outline: 1px solid #fff
-}
-
-.swagger-ui .debug-black * {
-  outline: 1px solid #000
-}
-
-.swagger-ui .debug-grid {
-  background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyhpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTExIDc5LjE1ODMyNSwgMjAxNS8wOS8xMC0wMToxMDoyMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MTRDOTY4N0U2N0VFMTFFNjg2MzZDQjkwNkQ4MjgwMEIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MTRDOTY4N0Q2N0VFMTFFNjg2MzZDQjkwNkQ4MjgwMEIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTUgKE1hY2ludG9zaCkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo3NjcyQkQ3NjY3QzUxMUU2QjJCQ0UyNDA4MTAwMjE3MSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo3NjcyQkQ3NzY3QzUxMUU2QjJCQ0UyNDA4MTAwMjE3MSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PsBS+GMAAAAjSURBVHjaYvz//z8DLsD4gcGXiYEAGBIKGBne//fFpwAgwAB98AaF2pjlUQAAAABJRU5ErkJggg==) repeat 0 0
-}
-
-.swagger-ui .debug-grid-16 {
-  background: transparent url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyhpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTExIDc5LjE1ODMyNSwgMjAxNS8wOS8xMC0wMToxMDoyMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6ODYyRjhERDU2N0YyMTFFNjg2MzZDQjkwNkQ4MjgwMEIiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6ODYyRjhERDQ2N0YyMTFFNjg2MzZDQjkwNkQ4MjgwMEIiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTUgKE1hY2ludG9zaCkiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo3NjcyQkQ3QTY3QzUxMUU2QjJCQ0UyNDA4MTAwMjE3MSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo3NjcyQkQ3QjY3QzUxMUU2QjJCQ0UyNDA4MTAwMjE3MSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PvCS01IAAABMSURBVHjaYmR4/5+BFPBfAMFm/MBgx8RAGWCn1AAmSg34Q6kBDKMGMDCwICeMIemF/5QawEipAWwUhwEjMDvbAWlWkvVBwu8vQIABAEwBCph8U6c0AAAAAElFTkSuQmCC) repeat 0 0
-}
-
-.swagger-ui .debug-grid-8-solid {
-  background: #fff url(data:image/jpeg;base64,/9j/4QAYRXhpZgAASUkqAAgAAAAAAAAAAAAAAP/sABFEdWNreQABAAQAAAAAAAD/4QMxaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLwA8P3hwYWNrZXQgYmVnaW49Iu+7vyIgaWQ9Ilc1TTBNcENlaGlIenJlU3pOVGN6a2M5ZCI/PiA8eDp4bXBtZXRhIHhtbG5zOng9ImFkb2JlOm5zOm1ldGEvIiB4OnhtcHRrPSJBZG9iZSBYTVAgQ29yZSA1LjYtYzExMSA3OS4xNTgzMjUsIDIwMTUvMDkvMTAtMDE6MTA6MjAgICAgICAgICI+IDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+IDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bXA6Q3JlYXRvclRvb2w9IkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE1IChNYWNpbnRvc2gpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOkIxMjI0OTczNjdCMzExRTZCMkJDRTI0MDgxMDAyMTcxIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOkIxMjI0OTc0NjdCMzExRTZCMkJDRTI0MDgxMDAyMTcxIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6QjEyMjQ5NzE2N0IzMTFFNkIyQkNFMjQwODEwMDIxNzEiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6QjEyMjQ5NzI2N0IzMTFFNkIyQkNFMjQwODEwMDIxNzEiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz7/7gAOQWRvYmUAZMAAAAAB/9sAhAAbGhopHSlBJiZBQi8vL0JHPz4+P0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHAR0pKTQmND8oKD9HPzU/R0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0f/wAARCAAIAAgDASIAAhEBAxEB/8QAWQABAQAAAAAAAAAAAAAAAAAAAAYBAQEAAAAAAAAAAAAAAAAAAAIEEAEBAAMBAAAAAAAAAAAAAAABADECA0ERAAEDBQAAAAAAAAAAAAAAAAARITFBUWESIv/aAAwDAQACEQMRAD8AoOnTV1QTD7JJshP3vSM3P//Z) repeat 0 0
-}
-
-.swagger-ui .debug-grid-16-solid {
-  background: #fff url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyhpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTExIDc5LjE1ODMyNSwgMjAxNS8wOS8xMC0wMToxMDoyMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTUgKE1hY2ludG9zaCkiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6NzY3MkJEN0U2N0M1MTFFNkIyQkNFMjQwODEwMDIxNzEiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6NzY3MkJEN0Y2N0M1MTFFNkIyQkNFMjQwODEwMDIxNzEiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo3NjcyQkQ3QzY3QzUxMUU2QjJCQ0UyNDA4MTAwMjE3MSIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo3NjcyQkQ3RDY3QzUxMUU2QjJCQ0UyNDA4MTAwMjE3MSIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pve6J3kAAAAzSURBVHjaYvz//z8D0UDsMwMjSRoYP5Gq4SPNbRjVMEQ1fCRDg+in/6+J1AJUxsgAEGAA31BAJMS0GYEAAAAASUVORK5CYII=) repeat 0 0
-}
-
-.swagger-ui .b--black {
-  border-color: #000
-}
-
-.swagger-ui .b--near-black {
-  border-color: #111
-}
-
-.swagger-ui .b--dark-gray {
-  border-color: #333
-}
-
-.swagger-ui .b--mid-gray {
-  border-color: #555
-}
-
-.swagger-ui .b--gray {
-  border-color: #777
-}
-
-.swagger-ui .b--silver {
-  border-color: #999
-}
-
-.swagger-ui .b--light-silver {
-  border-color: #aaa
-}
-
-.swagger-ui .b--moon-gray {
-  border-color: #ccc
-}
-
-.swagger-ui .b--light-gray {
-  border-color: #eee
-}
-
-.swagger-ui .b--near-white {
-  border-color: #f4f4f4
-}
-
-.swagger-ui .b--white {
-  border-color: #fff
-}
-
-.swagger-ui .b--white-90 {
-  border-color: hsla(0, 0%, 100%, .9)
-}
-
-.swagger-ui .b--white-80 {
-  border-color: hsla(0, 0%, 100%, .8)
-}
-
-.swagger-ui .b--white-70 {
-  border-color: hsla(0, 0%, 100%, .7)
-}
-
-.swagger-ui .b--white-60 {
-  border-color: hsla(0, 0%, 100%, .6)
-}
-
-.swagger-ui .b--white-50 {
-  border-color: hsla(0, 0%, 100%, .5)
-}
-
-.swagger-ui .b--white-40 {
-  border-color: hsla(0, 0%, 100%, .4)
-}
-
-.swagger-ui .b--white-30 {
-  border-color: hsla(0, 0%, 100%, .3)
-}
-
-.swagger-ui .b--white-20 {
-  border-color: hsla(0, 0%, 100%, .2)
-}
-
-.swagger-ui .b--white-10 {
-  border-color: hsla(0, 0%, 100%, .1)
-}
-
-.swagger-ui .b--white-05 {
-  border-color: hsla(0, 0%, 100%, .05)
-}
-
-.swagger-ui .b--white-025 {
-  border-color: hsla(0, 0%, 100%, .025)
-}
-
-.swagger-ui .b--white-0125 {
-  border-color: hsla(0, 0%, 100%, .0125)
-}
-
-.swagger-ui .b--black-90 {
-  border-color: rgba(0, 0, 0, .9)
-}
-
-.swagger-ui .b--black-80 {
-  border-color: rgba(0, 0, 0, .8)
-}
-
-.swagger-ui .b--black-70 {
-  border-color: rgba(0, 0, 0, .7)
-}
-
-.swagger-ui .b--black-60 {
-  border-color: rgba(0, 0, 0, .6)
-}
-
-.swagger-ui .b--black-50 {
-  border-color: rgba(0, 0, 0, .5)
-}
-
-.swagger-ui .b--black-40 {
-  border-color: rgba(0, 0, 0, .4)
-}
-
-.swagger-ui .b--black-30 {
-  border-color: rgba(0, 0, 0, .3)
-}
-
-.swagger-ui .b--black-20 {
-  border-color: rgba(0, 0, 0, .2)
-}
-
-.swagger-ui .b--black-10 {
-  border-color: rgba(0, 0, 0, .1)
-}
-
-.swagger-ui .b--black-05 {
-  border-color: rgba(0, 0, 0, .05)
-}
-
-.swagger-ui .b--black-025 {
-  border-color: rgba(0, 0, 0, .025)
-}
-
-.swagger-ui .b--black-0125 {
-  border-color: rgba(0, 0, 0, .0125)
-}
-
-.swagger-ui .b--dark-red {
-  border-color: #e7040f
-}
-
-.swagger-ui .b--red {
-  border-color: #ff4136
-}
-
-.swagger-ui .b--light-red {
-  border-color: #ff725c
-}
-
-.swagger-ui .b--orange {
-  border-color: #ff6300
-}
-
-.swagger-ui .b--gold {
-  border-color: #ffb700
-}
-
-.swagger-ui .b--yellow {
-  border-color: gold
-}
-
-.swagger-ui .b--light-yellow {
-  border-color: #fbf1a9
-}
-
-.swagger-ui .b--purple {
-  border-color: #5e2ca5
-}
-
-.swagger-ui .b--light-purple {
-  border-color: #a463f2
-}
-
-.swagger-ui .b--dark-pink {
-  border-color: #d5008f
-}
-
-.swagger-ui .b--hot-pink {
-  border-color: #ff41b4
-}
-
-.swagger-ui .b--pink {
-  border-color: #ff80cc
-}
-
-.swagger-ui .b--light-pink {
-  border-color: #ffa3d7
-}
-
-.swagger-ui .b--dark-green {
-  border-color: #137752
-}
-
-.swagger-ui .b--green {
-  border-color: #19a974
-}
-
-.swagger-ui .b--light-green {
-  border-color: #9eebcf
-}
-
-.swagger-ui .b--navy {
-  border-color: #001b44
-}
-
-.swagger-ui .b--dark-blue {
-  border-color: #00449e
-}
-
-.swagger-ui .b--blue {
-  border-color: #357edd
-}
-
-.swagger-ui .b--light-blue {
-  border-color: #96ccff
-}
-
-.swagger-ui .b--lightest-blue {
-  border-color: #cdecff
-}
-
-.swagger-ui .b--washed-blue {
-  border-color: #f6fffe
-}
-
-.swagger-ui .b--washed-green {
-  border-color: #e8fdf5
-}
-
-.swagger-ui .b--washed-yellow {
-  border-color: #fffceb
-}
-
-.swagger-ui .b--washed-red {
-  border-color: #ffdfdf
-}
-
-.swagger-ui .b--transparent {
-  border-color: transparent
-}
-
-.swagger-ui .b--inherit {
-  border-color: inherit
-}
-
-.swagger-ui .shadow-1 {
-  box-shadow: 0 0 4px 2px rgba(0, 0, 0, .2)
-}
-
-.swagger-ui .shadow-2 {
-  box-shadow: 0 0 8px 2px rgba(0, 0, 0, .2)
-}
-
-.swagger-ui .shadow-3 {
-  box-shadow: 2px 2px 4px 2px rgba(0, 0, 0, .2)
-}
-
-.swagger-ui .shadow-4 {
-  box-shadow: 2px 2px 8px 0 rgba(0, 0, 0, .2)
-}
-
-.swagger-ui .shadow-5 {
-  box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, .2)
-}
-
-@media screen and (min-width:30em) {
-  .swagger-ui .shadow-1-ns {
-    box-shadow: 0 0 4px 2px rgba(0, 0, 0, .2)
-  }
-  .swagger-ui .shadow-2-ns {
-    box-shadow: 0 0 8px 2px rgba(0, 0, 0, .2)
-  }
-  .swagger-ui .shadow-3-ns {
-    box-shadow: 2px 2px 4px 2px rgba(0, 0, 0, .2)
-  }
-  .swagger-ui .shadow-4-ns {
-    box-shadow: 2px 2px 8px 0 rgba(0, 0, 0, .2)
-  }
-  .swagger-ui .shadow-5-ns {
-    box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, .2)
-  }
-}
-
-@media screen and (min-width:30em) and (max-width:60em) {
-  .swagger-ui .shadow-1-m {
-    box-shadow: 0 0 4px 2px rgba(0, 0, 0, .2)
-  }
-  .swagger-ui .shadow-2-m {
-    box-shadow: 0 0 8px 2px rgba(0, 0, 0, .2)
-  }
-  .swagger-ui .shadow-3-m {
-    box-shadow: 2px 2px 4px 2px rgba(0, 0, 0, .2)
-  }
-  .swagger-ui .shadow-4-m {
-    box-shadow: 2px 2px 8px 0 rgba(0, 0, 0, .2)
-  }
-  .swagger-ui .shadow-5-m {
-    box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, .2)
-  }
-}
-
-@media screen and (min-width:60em) {
-  .swagger-ui .shadow-1-l {
-    box-shadow: 0 0 4px 2px rgba(0, 0, 0, .2)
-  }
-  .swagger-ui .shadow-2-l {
-    box-shadow: 0 0 8px 2px rgba(0, 0, 0, .2)
-  }
-  .swagger-ui .shadow-3-l {
-    box-shadow: 2px 2px 4px 2px rgba(0, 0, 0, .2)
-  }
-  .swagger-ui .shadow-4-l {
-    box-shadow: 2px 2px 8px 0 rgba(0, 0, 0, .2)
-  }
-  .swagger-ui .shadow-5-l {
-    box-shadow: 4px 4px 8px 0 rgba(0, 0, 0, .2)
-  }
-}
-
-.swagger-ui .black-90 {
-  color: rgba(0, 0, 0, .9)
-}
-
-.swagger-ui .black-80 {
-  color: rgba(0, 0, 0, .8)
-}
-
-.swagger-ui .black-70 {
-  color: rgba(0, 0, 0, .7)
-}
-
-.swagger-ui .black-60 {
-  color: rgba(0, 0, 0, .6)
-}
-
-.swagger-ui .black-50 {
-  color: rgba(0, 0, 0, .5)
-}
-
-.swagger-ui .black-40 {
-  color: rgba(0, 0, 0, .4)
-}
-
-.swagger-ui .black-30 {
-  color: rgba(0, 0, 0, .3)
-}
-
-.swagger-ui .black-20 {
-  color: rgba(0, 0, 0, .2)
-}
-
-.swagger-ui .black-10 {
-  color: rgba(0, 0, 0, .1)
-}
-
-.swagger-ui .black-05 {
-  color: rgba(0, 0, 0, .05)
-}
-
-.swagger-ui .white-90 {
-  color: hsla(0, 0%, 100%, .9)
-}
-
-.swagger-ui .white-80 {
-  color: hsla(0, 0%, 100%, .8)
-}
-
-.swagger-ui .white-70 {
-  color: hsla(0, 0%, 100%, .7)
-}
-
-.swagger-ui .white-60 {
-  color: hsla(0, 0%, 100%, .6)
-}
-
-.swagger-ui .white-50 {
-  color: hsla(0, 0%, 100%, .5)
-}
-
-.swagger-ui .white-40 {
-  color: hsla(0, 0%, 100%, .4)
-}
-
-.swagger-ui .white-30 {
-  color: hsla(0, 0%, 100%, .3)
-}
-
-.swagger-ui .white-20 {
-  color: hsla(0, 0%, 100%, .2)
-}
-
-.swagger-ui .white-10 {
-  color: hsla(0, 0%, 100%, .1)
-}
-
-.swagger-ui .black {
-  color: #000
-}
-
-.swagger-ui .near-black {
-  color: #111
-}
-
-.swagger-ui .dark-gray {
-  color: #333
-}
-
-.swagger-ui .mid-gray {
-  color: #555
-}
-
-.swagger-ui .gray {
-  color: #777
-}
-
-.swagger-ui .silver {
-  color: #999
-}
-
-.swagger-ui .light-silver {
-  color: #aaa
-}
-
-.swagger-ui .moon-gray {
-  color: #ccc
-}
-
-.swagger-ui .light-gray {
-  color: #eee
-}
-
-.swagger-ui .near-white {
-  color: #f4f4f4
-}
-
-.swagger-ui .white {
-  color: #fff
-}
-
-.swagger-ui .dark-red {
-  color: #e7040f
-}
-
-.swagger-ui .red {
-  color: #ff4136
-}
-
-.swagger-ui .light-red {
-  color: #ff725c
-}
-
-.swagger-ui .orange {
-  color: #ff6300
-}
-
-.swagger-ui .gold {
-  color: #ffb700
-}
-
-.swagger-ui .yellow {
-  color: gold
-}
-
-.swagger-ui .light-yellow {
-  color: #fbf1a9
-}
-
-.swagger-ui .purple {
-  color: #5e2ca5
-}
-
-.swagger-ui .light-purple {
-  color: #a463f2
-}
-
-.swagger-ui .dark-pink {
-  color: #d5008f
-}
-
-.swagger-ui .hot-pink {
-  color: #ff41b4
-}
-
-.swagger-ui .pink {
-  color: #ff80cc
-}
-
-.swagger-ui .light-pink {
-  color: #ffa3d7
-}
-
-.swagger-ui .dark-green {
-  color: #137752
-}
-
-.swagger-ui .green {
-  color: #19a974
-}
-
-.swagger-ui .light-green {
-  color: #9eebcf
-}
-
-.swagger-ui .navy {
-  color: #001b44
-}
-
-.swagger-ui .dark-blue {
-  color: #00449e
-}
-
-.swagger-ui .blue {
-  color: #357edd
-}
-
-.swagger-ui .light-blue {
-  color: #96ccff
-}
-
-.swagger-ui .lightest-blue {
-  color: #cdecff
-}
-
-.swagger-ui .washed-blue {
-  color: #f6fffe
-}
-
-.swagger-ui .washed-green {
-  color: #e8fdf5
-}
-
-.swagger-ui .washed-yellow {
-  color: #fffceb
-}
-
-.swagger-ui .washed-red {
-  color: #ffdfdf
-}
-
-.swagger-ui .color-inherit {
-  color: inherit
-}
-
-.swagger-ui .bg-black-90 {
-  background-color: rgba(0, 0, 0, .9)
-}
-
-.swagger-ui .bg-black-80 {
-  background-color: rgba(0, 0, 0, .8)
-}
-
-.swagger-ui .bg-black-70 {
-  background-color: rgba(0, 0, 0, .7)
-}
-
-.swagger-ui .bg-black-60 {
-  background-color: rgba(0, 0, 0, .6)
-}
-
-.swagger-ui .bg-black-50 {
-  background-color: rgba(0, 0, 0, .5)
-}
-
-.swagger-ui .bg-black-40 {
-  background-color: rgba(0, 0, 0, .4)
-}
-
-.swagger-ui .bg-black-30 {
-  background-color: rgba(0, 0, 0, .3)
-}
-
-.swagger-ui .bg-black-20 {
-  background-color: rgba(0, 0, 0, .2)
-}
-
-.swagger-ui .bg-black-10 {
-  background-color: rgba(0, 0, 0, .1)
-}
-
-.swagger-ui .bg-black-05 {
-  background-color: rgba(0, 0, 0, .05)
-}
-
-.swagger-ui .bg-white-90 {
-  background-color: hsla(0, 0%, 100%, .9)
-}
-
-.swagger-ui .bg-white-80 {
-  background-color: hsla(0, 0%, 100%, .8)
-}
-
-.swagger-ui .bg-white-70 {
-  background-color: hsla(0, 0%, 100%, .7)
-}
-
-.swagger-ui .bg-white-60 {
-  background-color: hsla(0, 0%, 100%, .6)
-}
-
-.swagger-ui .bg-white-50 {
-  background-color: hsla(0, 0%, 100%, .5)
-}
-
-.swagger-ui .bg-white-40 {
-  background-color: hsla(0, 0%, 100%, .4)
-}
-
-.swagger-ui .bg-white-30 {
-  background-color: hsla(0, 0%, 100%, .3)
-}
-
-.swagger-ui .bg-white-20 {
-  background-color: hsla(0, 0%, 100%, .2)
-}
-
-.swagger-ui .bg-white-10 {
-  background-color: hsla(0, 0%, 100%, .1)
-}
-
-.swagger-ui .bg-black {
-  background-color: #000
-}
-
-.swagger-ui .bg-near-black {
-  background-color: #111
-}
-
-.swagger-ui .bg-dark-gray {
-  background-color: #333
-}
-
-.swagger-ui .bg-mid-gray {
-  background-color: #555
-}
-
-.swagger-ui .bg-gray {
-  background-color: #777
-}
-
-.swagger-ui .bg-silver {
-  background-color: #999
-}
-
-.swagger-ui .bg-light-silver {
-  background-color: #aaa
-}
-
-.swagger-ui .bg-moon-gray {
-  background-color: #ccc
-}
-
-.swagger-ui .bg-light-gray {
-  background-color: #eee
-}
-
-.swagger-ui .bg-near-white {
-  background-color: #f4f4f4
-}
-
-.swagger-ui .bg-white {
-  background-color: #fff
-}
-
-.swagger-ui .bg-transparent {
-  background-color: transparent
-}
-
-.swagger-ui .bg-dark-red {
-  background-color: #e7040f
-}
-
-.swagger-ui .bg-red {
-  background-color: #ff4136
-}
-
-.swagger-ui .bg-light-red {
-  background-color: #ff725c
-}
-
-.swagger-ui .bg-orange {
-  background-color: #ff6300
-}
-
-.swagger-ui .bg-gold {
-  background-color: #ffb700
-}
-
-.swagger-ui .bg-yellow {
-  background-color: gold
-}
-
-.swagger-ui .bg-light-yellow {
-  background-color: #fbf1a9
-}
-
-.swagger-ui .bg-purple {
-  background-color: #5e2ca5
-}
-
-.swagger-ui .bg-light-purple {
-  background-color: #a463f2
-}
-
-.swagger-ui .bg-dark-pink {
-  background-color: #d5008f
-}
-
-.swagger-ui .bg-hot-pink {
-  background-color: #ff41b4
-}
-
-.swagger-ui .bg-pink {
-  background-color: #ff80cc
-}
-
-.swagger-ui .bg-light-pink {
-  background-color: #ffa3d7
-}
-
-.swagger-ui .bg-dark-green {
-  background-color: #137752
-}
-
-.swagger-ui .bg-green {
-  background-color: #19a974
-}
-
-.swagger-ui .bg-light-green {
-  background-color: #9eebcf
-}
-
-.swagger-ui .bg-navy {
-  background-color: #001b44
-}
-
-.swagger-ui .bg-dark-blue {
-  background-color: #00449e
-}
-
-.swagger-ui .bg-blue {
-  background-color: #357edd
-}
-
-.swagger-ui .bg-light-blue {
-  background-color: #96ccff
-}
-
-.swagger-ui .bg-lightest-blue {
-  background-color: #cdecff
-}
-
-.swagger-ui .bg-washed-blue {
-  background-color: #f6fffe
-}
-
-.swagger-ui .bg-washed-green {
-  background-color: #e8fdf5
-}
-
-.swagger-ui .bg-washed-yellow {
-  background-color: #fffceb
-}
-
-.swagger-ui .bg-washed-red {
-  background-color: #ffdfdf
-}
-
-.swagger-ui .hover-black:focus,
-.swagger-ui .hover-black:hover {
-  color: #000
-}
-
-.swagger-ui .hover-near-black:focus,
-.swagger-ui .hover-near-black:hover {
-  color: #111
-}
-
-.swagger-ui .hover-dark-gray:focus,
-.swagger-ui .hover-dark-gray:hover {
-  color: #333
-}
-
-.swagger-ui .hover-mid-gray:focus,
-.swagger-ui .hover-mid-gray:hover {
-  color: #555
-}
-
-.swagger-ui .hover-gray:focus,
-.swagger-ui .hover-gray:hover {
-  color: #777
-}
-
-.swagger-ui .hover-silver:focus,
-.swagger-ui .hover-silver:hover {
-  color: #999
-}
-
-.swagger-ui .hover-light-silver:focus,
-.swagger-ui .hover-light-silver:hover {
-  color: #aaa
-}
-
-.swagger-ui .hover-moon-gray:focus,
-.swagger-ui .hover-moon-gray:hover {
-  color: #ccc
-}
-
-.swagger-ui .hover-light-gray:focus,
-.swagger-ui .hover-light-gray:hover {
-  color: #eee
-}
-
-.swagger-ui .hover-near-white:focus,
-.swagger-ui .hover-near-white:hover {
-  color: #f4f4f4
-}
-
-.swagger-ui .hover-white:focus,
-.swagger-ui .hover-white:hover {
-  color: #fff
-}
-
-.swagger-ui .hover-black-90:focus,
-.swagger-ui .hover-black-90:hover {
-  color: rgba(0, 0, 0, .9)
-}
-
-.swagger-ui .hover-black-80:focus,
-.swagger-ui .hover-black-80:hover {
-  color: rgba(0, 0, 0, .8)
-}
-
-.swagger-ui .hover-black-70:focus,
-.swagger-ui .hover-black-70:hover {
-  color: rgba(0, 0, 0, .7)
-}
-
-.swagger-ui .hover-black-60:focus,
-.swagger-ui .hover-black-60:hover {
-  color: rgba(0, 0, 0, .6)
-}
-
-.swagger-ui .hover-black-50:focus,
-.swagger-ui .hover-black-50:hover {
-  color: rgba(0, 0, 0, .5)
-}
-
-.swagger-ui .hover-black-40:focus,
-.swagger-ui .hover-black-40:hover {
-  color: rgba(0, 0, 0, .4)
-}
-
-.swagger-ui .hover-black-30:focus,
-.swagger-ui .hover-black-30:hover {
-  color: rgba(0, 0, 0, .3)
-}
-
-.swagger-ui .hover-black-20:focus,
-.swagger-ui .hover-black-20:hover {
-  color: rgba(0, 0, 0, .2)
-}
-
-.swagger-ui .hover-black-10:focus,
-.swagger-ui .hover-black-10:hover {
-  color: rgba(0, 0, 0, .1)
-}
-
-.swagger-ui .hover-white-90:focus,
-.swagger-ui .hover-white-90:hover {
-  color: hsla(0, 0%, 100%, .9)
-}
-
-.swagger-ui .hover-white-80:focus,
-.swagger-ui .hover-white-80:hover {
-  color: hsla(0, 0%, 100%, .8)
-}
-
-.swagger-ui .hover-white-70:focus,
-.swagger-ui .hover-white-70:hover {
-  color: hsla(0, 0%, 100%, .7)
-}
-
-.swagger-ui .hover-white-60:focus,
-.swagger-ui .hover-white-60:hover {
-  color: hsla(0, 0%, 100%, .6)
-}
-
-.swagger-ui .hover-white-50:focus,
-.swagger-ui .hover-white-50:hover {
-  color: hsla(0, 0%, 100%, .5)
-}
-
-.swagger-ui .hover-white-40:focus,
-.swagger-ui .hover-white-40:hover {
-  color: hsla(0, 0%, 100%, .4)
-}
-
-.swagger-ui .hover-white-30:focus,
-.swagger-ui .hover-white-30:hover {
-  color: hsla(0, 0%, 100%, .3)
-}
-
-.swagger-ui .hover-white-20:focus,
-.swagger-ui .hover-white-20:hover {
-  color: hsla(0, 0%, 100%, .2)
-}
-
-.swagger-ui .hover-white-10:focus,
-.swagger-ui .hover-white-10:hover {
-  color: hsla(0, 0%, 100%, .1)
-}
-
-.swagger-ui .hover-inherit:focus,
-.swagger-ui .hover-inherit:hover {
-  color: inherit
-}
-
-.swagger-ui .hover-bg-black:focus,
-.swagger-ui .hover-bg-black:hover {
-  background-color: #000
-}
-
-.swagger-ui .hover-bg-near-black:focus,
-.swagger-ui .hover-bg-near-black:hover {
-  background-color: #111
-}
-
-.swagger-ui .hover-bg-dark-gray:focus,
-.swagger-ui .hover-bg-dark-gray:hover {
-  background-color: #333
-}
-
-.swagger-ui .hover-bg-mid-gray:focus,
-.swagger-ui .hover-bg-mid-gray:hover {
-  background-color: #555
-}
-
-.swagger-ui .hover-bg-gray:focus,
-.swagger-ui .hover-bg-gray:hover {
-  background-color: #777
-}
-
-.swagger-ui .hover-bg-silver:focus,
-.swagger-ui .hover-bg-silver:hover {
-  background-color: #999
-}
-
-.swagger-ui .hover-bg-light-silver:focus,
-.swagger-ui .hover-bg-light-silver:hover {
-  background-color: #aaa
-}
-
-.swagger-ui .hover-bg-moon-gray:focus,
-.swagger-ui .hover-bg-moon-gray:hover {
-  background-color: #ccc
-}
-
-.swagger-ui .hover-bg-light-gray:focus,
-.swagger-ui .hover-bg-light-gray:hover {
-  background-color: #eee
-}
-
-.swagger-ui .hover-bg-near-white:focus,
-.swagger-ui .hover-bg-near-white:hover {
-  background-color: #f4f4f4
-}
-
-.swagger-ui .hover-bg-white:focus,
-.swagger-ui .hover-bg-white:hover {
-  background-color: #fff
-}
-
-.swagger-ui .hover-bg-transparent:focus,
-.swagger-ui .hover-bg-transparent:hover {
-  background-color: transparent
-}
-
-.swagger-ui .hover-bg-black-90:focus,
-.swagger-ui .hover-bg-black-90:hover {
-  background-color: rgba(0, 0, 0, .9)
-}
-
-.swagger-ui .hover-bg-black-80:focus,
-.swagger-ui .hover-bg-black-80:hover {
-  background-color: rgba(0, 0, 0, .8)
-}
-
-.swagger-ui .hover-bg-black-70:focus,
-.swagger-ui .hover-bg-black-70:hover {
-  background-color: rgba(0, 0, 0, .7)
-}
-
-.swagger-ui .hover-bg-black-60:focus,
-.swagger-ui .hover-bg-black-60:hover {
-  background-color: rgba(0, 0, 0, .6)
-}
-
-.swagger-ui .hover-bg-black-50:focus,
-.swagger-ui .hover-bg-black-50:hover {
-  background-color: rgba(0, 0, 0, .5)
-}
-
-.swagger-ui .hover-bg-black-40:focus,
-.swagger-ui .hover-bg-black-40:hover {
-  background-color: rgba(0, 0, 0, .4)
-}
-
-.swagger-ui .hover-bg-black-30:focus,
-.swagger-ui .hover-bg-black-30:hover {
-  background-color: rgba(0, 0, 0, .3)
-}
-
-.swagger-ui .hover-bg-black-20:focus,
-.swagger-ui .hover-bg-black-20:hover {
-  background-color: rgba(0, 0, 0, .2)
-}
-
-.swagger-ui .hover-bg-black-10:focus,
-.swagger-ui .hover-bg-black-10:hover {
-  background-color: rgba(0, 0, 0, .1)
-}
-
-.swagger-ui .hover-bg-white-90:focus,
-.swagger-ui .hover-bg-white-90:hover {
-  background-color: hsla(0, 0%, 100%, .9)
-}
-
-.swagger-ui .hover-bg-white-80:focus,
-.swagger-ui .hover-bg-white-80:hover {
-  background-color: hsla(0, 0%, 100%, .8)
-}
-
-.swagger-ui .hover-bg-white-70:focus,
-.swagger-ui .hover-bg-white-70:hover {
-  background-color: hsla(0, 0%, 100%, .7)
-}
-
-.swagger-ui .hover-bg-white-60:focus,
-.swagger-ui .hover-bg-white-60:hover {
-  background-color: hsla(0, 0%, 100%, .6)
-}
-
-.swagger-ui .hover-bg-white-50:focus,
-.swagger-ui .hover-bg-white-50:hover {
-  background-color: hsla(0, 0%, 100%, .5)
-}
-
-.swagger-ui .hover-bg-white-40:focus,
-.swagger-ui .hover-bg-white-40:hover {
-  background-color: hsla(0, 0%, 100%, .4)
-}
-
-.swagger-ui .hover-bg-white-30:focus,
-.swagger-ui .hover-bg-white-30:hover {
-  background-color: hsla(0, 0%, 100%, .3)
-}
-
-.swagger-ui .hover-bg-white-20:focus,
-.swagger-ui .hover-bg-white-20:hover {
-  background-color: hsla(0, 0%, 100%, .2)
-}
-
-.swagger-ui .hover-bg-white-10:focus,
-.swagger-ui .hover-bg-white-10:hover {
-  background-color: hsla(0, 0%, 100%, .1)
-}
-
-.swagger-ui .hover-dark-red:focus,
-.swagger-ui .hover-dark-red:hover {
-  color: #e7040f
-}
-
-.swagger-ui .hover-red:focus,
-.swagger-ui .hover-red:hover {
-  color: #ff4136
-}
-
-.swagger-ui .hover-light-red:focus,
-.swagger-ui .hover-light-red:hover {
-  color: #ff725c
-}
-
-.swagger-ui .hover-orange:focus,
-.swagger-ui .hover-orange:hover {
-  color: #ff6300
-}
-
-.swagger-ui .hover-gold:focus,
-.swagger-ui .hover-gold:hover {
-  color: #ffb700
-}
-
-.swagger-ui .hover-yellow:focus,
-.swagger-ui .hover-yellow:hover {
-  color: gold
-}
-
-.swagger-ui .hover-light-yellow:focus,
-.swagger-ui .hover-light-yellow:hover {
-  color: #fbf1a9
-}
-
-.swagger-ui .hover-purple:focus,
-.swagger-ui .hover-purple:hover {
-  color: #5e2ca5
-}
-
-.swagger-ui .hover-light-purple:focus,
-.swagger-ui .hover-light-purple:hover {
-  color: #a463f2
-}
-
-.swagger-ui .hover-dark-pink:focus,
-.swagger-ui .hover-dark-pink:hover {
-  color: #d5008f
-}
-
-.swagger-ui .hover-hot-pink:focus,
-.swagger-ui .hover-hot-pink:hover {
-  color: #ff41b4
-}
-
-.swagger-ui .hover-pink:focus,
-.swagger-ui .hover-pink:hover {
-  color: #ff80cc
-}
-
-.swagger-ui .hover-light-pink:focus,
-.swagger-ui .hover-light-pink:hover {
-  color: #ffa3d7
-}
-
-.swagger-ui .hover-dark-green:focus,
-.swagger-ui .hover-dark-green:hover {
-  color: #137752
-}
-
-.swagger-ui .hover-green:focus,
-.swagger-ui .hover-green:hover {
-  color: #19a974
-}
-
-.swagger-ui .hover-light-green:focus,
-.swagger-ui .hover-light-green:hover {
-  color: #9eebcf
-}
-
-.swagger-ui .hover-navy:focus,
-.swagger-ui .hover-navy:hover {
-  color: #001b44
-}
-
-.swagger-ui .hover-dark-blue:focus,
-.swagger-ui .hover-dark-blue:hover {
-  color: #00449e
-}
-
-.swagger-ui .hover-blue:focus,
-.swagger-ui .hover-blue:hover {
-  color: #357edd
-}
-
-.swagger-ui .hover-light-blue:focus,
-.swagger-ui .hover-light-blue:hover {
-  color: #96ccff
-}
-
-.swagger-ui .hover-lightest-blue:focus,
-.swagger-ui .hover-lightest-blue:hover {
-  color: #cdecff
-}
-
-.swagger-ui .hover-washed-blue:focus,
-.swagger-ui .hover-washed-blue:hover {
-  color: #f6fffe
-}
-
-.swagger-ui .hover-washed-green:focus,
-.swagger-ui .hover-washed-green:hover {
-  color: #e8fdf5
-}
-
-.swagger-ui .hover-washed-yellow:focus,
-.swagger-ui .hover-washed-yellow:hover {
-  color: #fffceb
-}
-
-.swagger-ui .hover-washed-red:focus,
-.swagger-ui .hover-washed-red:hover {
-  color: #ffdfdf
-}
-
-.swagger-ui .hover-bg-dark-red:focus,
-.swagger-ui .hover-bg-dark-red:hover {
-  background-color: #e7040f
-}
-
-.swagger-ui .hover-bg-red:focus,
-.swagger-ui .hover-bg-red:hover {
-  background-color: #ff4136
-}
-
-.swagger-ui .hover-bg-light-red:focus,
-.swagger-ui .hover-bg-light-red:hover {
-  background-color: #ff725c
-}
-
-.swagger-ui .hover-bg-orange:focus,
-.swagger-ui .hover-bg-orange:hover {
-  background-color: #ff6300
-}
-
-.swagger-ui .hover-bg-gold:focus,
-.swagger-ui .hover-bg-gold:hover {
-  background-color: #ffb700
-}
-
-.swagger-ui .hover-bg-yellow:focus,
-.swagger-ui .hover-bg-yellow:hover {
-  background-color: gold
-}
-
-.swagger-ui .hover-bg-light-yellow:focus,
-.swagger-ui .hover-bg-light-yellow:hover {
-  background-color: #fbf1a9
-}
-
-.swagger-ui .hover-bg-purple:focus,
-.swagger-ui .hover-bg-purple:hover {
-  background-color: #5e2ca5
-}
-
-.swagger-ui .hover-bg-light-purple:focus,
-.swagger-ui .hover-bg-light-purple:hover {
-  background-color: #a463f2
-}
-
-.swagger-ui .hover-bg-dark-pink:focus,
-.swagger-ui .hover-bg-dark-pink:hover {
-  background-color: #d5008f
-}
-
-.swagger-ui .hover-bg-hot-pink:focus,
-.swagger-ui .hover-bg-hot-pink:hover {
-  background-color: #ff41b4
-}
-
-.swagger-ui .hover-bg-pink:focus,
-.swagger-ui .hover-bg-pink:hover {
-  background-color: #ff80cc
-}
-
-.swagger-ui .hover-bg-light-pink:focus,
-.swagger-ui .hover-bg-light-pink:hover {
-  background-color: #ffa3d7
-}
-
-.swagger-ui .hover-bg-dark-green:focus,
-.swagger-ui .hover-bg-dark-green:hover {
-  background-color: #137752
-}
-
-.swagger-ui .hover-bg-green:focus,
-.swagger-ui .hover-bg-green:hover {
-  background-color: #19a974
-}
-
-.swagger-ui .hover-bg-light-green:focus,
-.swagger-ui .hover-bg-light-green:hover {
-  background-color: #9eebcf
-}
-
-.swagger-ui .hover-bg-navy:focus,
-.swagger-ui .hover-bg-navy:hover {
-  background-color: #001b44
-}
-
-.swagger-ui .hover-bg-dark-blue:focus,
-.swagger-ui .hover-bg-dark-blue:hover {
-  background-color: #00449e
-}
-
-.swagger-ui .hover-bg-blue:focus,
-.swagger-ui .hover-bg-blue:hover {
-  background-color: #357edd
-}
-
-.swagger-ui .hover-bg-light-blue:focus,
-.swagger-ui .hover-bg-light-blue:hover {
-  background-color: #96ccff
-}
-
-.swagger-ui .hover-bg-lightest-blue:focus,
-.swagger-ui .hover-bg-lightest-blue:hover {
-  background-color: #cdecff
-}
-
-.swagger-ui .hover-bg-washed-blue:focus,
-.swagger-ui .hover-bg-washed-blue:hover {
-  background-color: #f6fffe
-}
-
-.swagger-ui .hover-bg-washed-green:focus,
-.swagger-ui .hover-bg-washed-green:hover {
-  background-color: #e8fdf5
-}
-
-.swagger-ui .hover-bg-washed-yellow:focus,
-.swagger-ui .hover-bg-washed-yellow:hover {
-  background-color: #fffceb
-}
-
-.swagger-ui .hover-bg-washed-red:focus,
-.swagger-ui .hover-bg-washed-red:hover {
-  background-color: #ffdfdf
-}
-
-.swagger-ui .hover-bg-inherit:focus,
-.swagger-ui .hover-bg-inherit:hover {
-  background-color: inherit
-}
-
-.swagger-ui .striped--light-silver:nth-child(odd) {
-  background-color: #aaa
-}
-
-.swagger-ui .striped--moon-gray:nth-child(odd) {
-  background-color: #ccc
-}
-
-.swagger-ui .striped--light-gray:nth-child(odd) {
-  background-color: #eee
-}
-
-.swagger-ui .striped--near-white:nth-child(odd) {
-  background-color: #f4f4f4
-}
-
-.swagger-ui .stripe-light:nth-child(odd) {
-  background-color: hsla(0, 0%, 100%, .1)
-}
-
-.swagger-ui .stripe-dark:nth-child(odd) {
-  background-color: rgba(0, 0, 0, .1)
-}
-
-.swagger-ui .nested-links a {
-  color: #357edd;
-}
-
-.swagger-ui .nested-links a:focus,
-.swagger-ui .nested-links a:hover {
-  color: #96ccff;
+  --scm-secondary-background: #050514;
+  --scm-secondary-text: white;
+  --scm-border: 2px solid whitesmoke;
+  --scm-hover-color: #7a7a7a;
+  --scm-column-selection: #12739c;
+  --sh-base-color: #fff;
+  --sh-font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+  --sh-block-background: #050514;
+  --sh-inline-code-color: #ff3860;
+  --sh-inline-code-background: #fbe7eb;
+  --sh-comment-color: #9a9a9a;
+  --sh-punctuation-color: #999999;
+  --sh-property-color: #2c99c7;
+  --sh-selector-color: #009dff;
+  --sh-operator-color: #999999;
+  --sh-operator-bg: inherit;
+  --sh-variable-color: #c386ca;
+  --sh-function-color: #ff6181;
+  --sh-keyword-color: #00a984;
+  --sh-selected-color: #947600;
+  --sh-highlight-background: #f5f5f5;
+  --sh-highlight-accent: #99d8f3;
+  --diff-background-color: #050514;
+  --diff-text-color: #fafafa;
+  --diff-font-family: Consolas, Courier, monospace;
+  --diff-selection-background-color: #b3d7ff;
+  --diff-gutter-insert-background-color: #05c71d;
+  --diff-gutter-delete-background-color: #eb7a85;
+  --diff-gutter-selected-background-color: #fffce0;
+  --diff-code-insert-background-color: #05240b;
+  --diff-code-delete-background-color: #230608;
+  --diff-code-insert-edit-background-color: #c0dc91;
+  --diff-code-delete-edit-background-color: #000;
+  --diff-code-selected-background-color: #fffce0;
+  --diff-omit-gutter-line-color: #cb2a1d;
+
+  --scm-primary-color: #00d1df;
+  --scm-link-color: #33b2e8;
+  --scm-info-color: #33b2e8;
+  --scm-success-color: #00c79b;
+  --scm-warning-color: #ffdd57;
+  --scm-danger-color: #e63453;
+  --scm-secondary-least-color: #050514;
+  --scm-secondary-less-color: #242424;
+  --scm-secondary-color: #fafafa;
+  --scm-secondary-more-color: whitesmoke;
+  --scm-secondary-most-color: white;
+}
+
+.swagger-ui {
+  color: var(--scm-secondary-text);
 }
 
 .swagger-ui .opblock-tag {
-  border-bottom: 1px solid rgba(59, 65, 81, .3)
+  border-bottom: var(--scm-border)
 }
 
-.swagger-ui .opblock-tag:hover {
-  background: rgba(0, 0, 0, .02)
-}
-
-.swagger-ui .opblock-tag {
-  color: #3b4151
-}
-
-.swagger-ui .opblock-tag small {
-  color: #3b4151
-}
-
+.swagger-ui .opblock-tag,
+.swagger-ui .opblock-tag small,
 .swagger-ui .parameter__type {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .opblock {
-  border: 1px solid #000;
-  box-shadow: 0 0 3px rgba(0, 0, 0, .19)
+  border: var(--scm-border)
 }
 
 .swagger-ui .opblock .tab-header .tab-item.active h4 span:after {
-  background: grey
+  background: var(--scm-secondary-color)
 }
 
 .swagger-ui .opblock.is-open .opblock-summary {
@@ -1427,16 +76,16 @@
 }
 
 .swagger-ui .opblock .opblock-section-header {
-  background: hsla(0, 0%, 100%, .8);
+  background: var(--scm-secondary-less-color);
   box-shadow: 0 1px 2px rgba(0, 0, 0, .1)
 }
 
 .swagger-ui .opblock .opblock-section-header>label {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .opblock .opblock-section-header h4 {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .opblock .opblock-summary-method {
@@ -1448,28 +97,32 @@
 .swagger-ui .opblock .opblock-summary-operation-id,
 .swagger-ui .opblock .opblock-summary-path,
 .swagger-ui .opblock .opblock-summary-path__deprecated {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .opblock .opblock-summary-description {
-  color: #3b4151
+  color: var(--scm-secondary-text)
+}
+
+.swagger-ui .authorization__btn.unlocked {
+  fill: var(--scm-secondary-text);
 }
 
 .swagger-ui .opblock.opblock-post {
-  border-color: #49cc90;
+  border-color: var(--scm-success-color);
   background: rgba(73, 204, 144, .1)
 }
 
 .swagger-ui .opblock.opblock-post .opblock-summary-method {
-  background: #49cc90
+  background: var(--scm-success-color)
 }
 
 .swagger-ui .opblock.opblock-post .opblock-summary {
-  border-color: #49cc90
+  border-color: var(--scm-success-color)
 }
 
 .swagger-ui .opblock.opblock-post .tab-header .tab-item.active h4 span:after {
-  background: #49cc90
+  background: var(--scm-success-color)
 }
 
 .swagger-ui .opblock.opblock-put {
@@ -1490,37 +143,37 @@
 }
 
 .swagger-ui .opblock.opblock-delete {
-  border-color: #f93e3e;
+  border-color: var(--scm-danger-color);
   background: rgba(249, 62, 62, .1)
 }
 
 .swagger-ui .opblock.opblock-delete .opblock-summary-method {
-  background: #f93e3e
+  background: var(--scm-danger-color)
 }
 
 .swagger-ui .opblock.opblock-delete .opblock-summary {
-  border-color: #f93e3e
+  border-color: var(--scm-danger-color)
 }
 
 .swagger-ui .opblock.opblock-delete .tab-header .tab-item.active h4 span:after {
-  background: #f93e3e
+  background: var(--scm-danger-color)
 }
 
 .swagger-ui .opblock.opblock-get {
-  border-color: #61affe;
+  border-color: var(--scm-info-color);
   background: rgba(97, 175, 254, .1)
 }
 
 .swagger-ui .opblock.opblock-get .opblock-summary-method {
-  background: #61affe
+  background: var(--scm-info-color)
 }
 
 .swagger-ui .opblock.opblock-get .opblock-summary {
-  border-color: #61affe
+  border-color: var(--scm-info-color)
 }
 
 .swagger-ui .opblock.opblock-get .tab-header .tab-item.active h4 span:after {
-  background: #61affe
+  background: var(--scm-info-color)
 }
 
 .swagger-ui .opblock.opblock-patch {
@@ -1606,7 +259,7 @@
 }
 
 .swagger-ui .tab li {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .tab li:first-of-type:after {
@@ -1616,28 +269,28 @@
 .swagger-ui .opblock-description-wrapper,
 .swagger-ui .opblock-external-docs-wrapper,
 .swagger-ui .opblock-title_normal {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .opblock-description-wrapper h4,
 .swagger-ui .opblock-external-docs-wrapper h4,
 .swagger-ui .opblock-title_normal h4 {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .opblock-description-wrapper p,
 .swagger-ui .opblock-external-docs-wrapper p,
 .swagger-ui .opblock-title_normal p {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .responses-inner h4,
 .swagger-ui .responses-inner h5 {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .response-col_status {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .response-col_status .response-undocumented {
@@ -1645,7 +298,7 @@
 }
 
 .swagger-ui .response-col_links {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .response-col_links .response-undocumented {
@@ -1663,16 +316,15 @@
 }
 
 .swagger-ui .scheme-container {
-  background: #fff;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, .15)
+  background: var(--scm-secondary-less-color)
 }
 
 .swagger-ui .scheme-container .schemes>label {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .loading-container .loading:after {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .loading-container .loading:before {
@@ -1689,7 +341,7 @@
 }
 
 .swagger-ui section h3 {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .fallback {
@@ -1711,7 +363,7 @@
 .swagger-ui .btn {
   border: 2px solid grey;
   box-shadow: 0 1px 2px rgba(0, 0, 0, .1);
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .btn:hover {
@@ -1725,18 +377,18 @@
 }
 
 .swagger-ui .btn.authorize {
-  color: #49cc90;
-  border-color: #49cc90;
+  color: var(--scm-primary-color);
+  border-color: var(--scm-primary-color);
 }
 
 .swagger-ui .btn.authorize svg {
-  fill: #49cc90
+  fill: var(--scm-primary-color)
 }
 
 .swagger-ui .btn.execute {
-  background-color: #4990e2;
+  background-color: var(--scm-info-color);
   color: #fff;
-  border-color: #4990e2
+  border-color: var(--scm-info-color)
 }
 
 .swagger-ui .expand-methods:hover svg {
@@ -1748,7 +400,7 @@
 }
 
 .swagger-ui button.invalid {
-  border-color: #f93e3e;
+  border-color: var(--scm-danger-color);
   background: #feebeb
 }
 
@@ -1762,9 +414,16 @@
 
 .swagger-ui select {
   border: 2px solid #41444e;
-  background: #f7f7f7 url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M13.418 7.859a.695.695 0 01.978 0 .68.68 0 010 .969l-3.908 3.83a.697.697 0 01-.979 0l-3.908-3.83a.68.68 0 010-.969.695.695 0 01.978 0L10 11l3.418-3.141z"/></svg>') right 10px center no-repeat;
+  /* use default select arrow instead */
+  background: var(--scm-secondary-background);
+  appearance: auto;
+  padding: 5px 10px;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, .25);
-  color: #3b4151;
+  color: var(--scm-secondary-text);
+}
+
+.swagger-ui-select-svg-fill {
+  fill: var(--scm-secondary-text);
 }
 
 .swagger-ui select[multiple] {
@@ -1772,12 +431,12 @@
 }
 
 .swagger-ui select.invalid {
-  border-color: #f93e3e;
+  border-color: var(--scm-danger-color);
   background: #feebeb
 }
 
 .swagger-ui label {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui input[type=email],
@@ -1796,7 +455,7 @@
 .swagger-ui input[type=search].invalid,
 .swagger-ui input[type=text].invalid,
 .swagger-ui textarea.invalid {
-  border-color: #f93e3e;
+  border-color: var(--scm-danger-color);
   background: #feebeb
 }
 
@@ -1818,11 +477,11 @@
 
 .swagger-ui textarea {
   background: hsla(0, 0%, 100%, .8);
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui textarea:focus {
-  border: 2px solid #61affe
+  border: 2px solid var(--scm-info-color)
 }
 
 .swagger-ui textarea.curl {
@@ -1835,7 +494,7 @@
 }
 
 .swagger-ui .checkbox p {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .checkbox input[type=checkbox]+label>.item {
@@ -1852,29 +511,33 @@
 }
 
 .swagger-ui .dialog-ux .modal-ux {
-  border: 1px solid #ebebeb;
-  background: #fff;
+  border: var(--scm-border);
+  background: var(--scm-secondary-less-color);
   box-shadow: 0 10px 30px 0 rgba(0, 0, 0, .2)
 }
 
 .swagger-ui .dialog-ux .modal-ux-content p {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .dialog-ux .modal-ux-content h4 {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .dialog-ux .modal-ux-header {
-  border-bottom: 1px solid #ebebeb;
+  border-bottom: var(--scm-border);
 }
 
 .swagger-ui .dialog-ux .modal-ux-header h3 {
-  color: #3b4151
+  color: var(--scm-secondary-text)
+}
+
+.swagger-ui .dialog-ux .modal-ux-header .close-modal {
+  fill: var(--scm-secondary-text)
 }
 
 .swagger-ui .model {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .model .deprecated span,
@@ -1882,6 +545,7 @@
   color: #a0a0a0!important
 }
 
+/*TODO: replace for schema in endpoint view */
 .swagger-ui .model-toggle:after {
   background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>') 50% no-repeat;
 }
@@ -1912,15 +576,15 @@
 }
 
 .swagger-ui section.models {
-  border: 1px solid rgba(59, 65, 81, .3);
+  border: var(--scm-border);
 }
 
 .swagger-ui section.models.is-open h4 {
-  border-bottom: 1px solid rgba(59, 65, 81, .3)
+  border-bottom: var(--scm-border)
 }
 
 .swagger-ui section.models h4 {
-  color: #606060
+  color: var(--scm-secondary-more-color)
 }
 
 .swagger-ui section.models h4:hover {
@@ -1931,24 +595,27 @@
   color: #707070
 }
 
+/* todo check */
 .swagger-ui section.models .model-container {
   background: rgba(0, 0, 0, .05)
 }
 
+/* todo check */
 .swagger-ui section.models .model-container:hover {
   background: rgba(0, 0, 0, .07)
 }
 
+/* todo check */
 .swagger-ui .model-box {
   background: rgba(0, 0, 0, .1)
 }
 
 .swagger-ui .model-title {
-  color: #505050
+  color: var(--scm-secondary-color)
 }
 
 .swagger-ui .model-deprecated-warning {
-  color: #f93e3e
+  color: var(--scm-danger-color)
 }
 
 .swagger-ui .prop-type {
@@ -1956,15 +623,15 @@
 }
 
 .swagger-ui .prop-format {
-  color: #606060
+  color: var(--scm-secondary-more-color)
 }
 
 .swagger-ui .servers>label {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui table.headers td {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui table.headers .header-example {
@@ -1974,11 +641,11 @@
 .swagger-ui table thead tr td,
 .swagger-ui table thead tr th {
   border-bottom: 1px solid rgba(59, 65, 81, .2);
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .parameter__name {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .parameter__name.required span {
@@ -2030,7 +697,7 @@
 .swagger-ui .info li,
 .swagger-ui .info p,
 .swagger-ui .info table {
-  color: #3b4151
+  color: var(--scm-secondary-text);
 }
 
 .swagger-ui .info h1,
@@ -2038,23 +705,24 @@
 .swagger-ui .info h3,
 .swagger-ui .info h4,
 .swagger-ui .info h5 {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .info a {
-  color: #4990e2
+  color: var(--scm-info-color)
 }
 
 .swagger-ui .info a:hover {
-  color: #1f69c0
+  color: inherit;
 }
 
 .swagger-ui .info .base-url {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .info .title {
-  color: #3b4151
+  color: #fafafa;
+  font-size: 2rem;
 }
 
 .swagger-ui .info .title small {
@@ -2070,37 +738,37 @@
 }
 
 .swagger-ui .auth-container {
-  border-bottom: 1px solid #ebebeb
+  border-bottom: var(--scm-border)
 }
 
 .swagger-ui .auth-container .errors {
   background-color: #fee;
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .scopes h2 {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .scopes h2 a {
-  color: #4990e2;
+  color: var(--scm-info-color);
 }
 
 .swagger-ui .errors-wrapper {
-  border: 2px solid #f93e3e;
+  border: 2px solid var(--scm-danger-color);
   background: rgba(249, 62, 62, .1)
 }
 
 .swagger-ui .errors-wrapper .errors h4 {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .errors-wrapper .errors small {
-  color: #606060
+  color: var(--scm-secondary-more-color)
 }
 
 .swagger-ui .errors-wrapper hgroup h4 {
-  color: #3b4151
+  color: var(--scm-secondary-text)
 }
 
 .swagger-ui .markdown pre,

--- a/src/main/js/swaggerUIColors.css
+++ b/src/main/js/swaggerUIColors.css
@@ -1,54 +1,3 @@
-/* TODO: Remove css vars! Only for test purpose! */
-.swagger-ui {
-  --scm-secondary-background: #050514;
-  --scm-secondary-text: white;
-  --scm-border: 2px solid whitesmoke;
-  --scm-hover-color: #7a7a7a;
-  --scm-column-selection: #12739c;
-  --sh-base-color: #fff;
-  --sh-font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
-  --sh-block-background: #050514;
-  --sh-inline-code-color: #ff3860;
-  --sh-inline-code-background: #fbe7eb;
-  --sh-comment-color: #9a9a9a;
-  --sh-punctuation-color: #999999;
-  --sh-property-color: #2c99c7;
-  --sh-selector-color: #009dff;
-  --sh-operator-color: #999999;
-  --sh-operator-bg: inherit;
-  --sh-variable-color: #c386ca;
-  --sh-function-color: #ff6181;
-  --sh-keyword-color: #00a984;
-  --sh-selected-color: #947600;
-  --sh-highlight-background: #f5f5f5;
-  --sh-highlight-accent: #99d8f3;
-  --diff-background-color: #050514;
-  --diff-text-color: #fafafa;
-  --diff-font-family: Consolas, Courier, monospace;
-  --diff-selection-background-color: #b3d7ff;
-  --diff-gutter-insert-background-color: #05c71d;
-  --diff-gutter-delete-background-color: #eb7a85;
-  --diff-gutter-selected-background-color: #fffce0;
-  --diff-code-insert-background-color: #05240b;
-  --diff-code-delete-background-color: #230608;
-  --diff-code-insert-edit-background-color: #c0dc91;
-  --diff-code-delete-edit-background-color: #000;
-  --diff-code-selected-background-color: #fffce0;
-  --diff-omit-gutter-line-color: #cb2a1d;
-
-  --scm-primary-color: #00d1df;
-  --scm-link-color: #33b2e8;
-  --scm-info-color: #33b2e8;
-  --scm-success-color: #00c79b;
-  --scm-warning-color: #ffdd57;
-  --scm-danger-color: #e63453;
-  --scm-secondary-least-color: #050514;
-  --scm-secondary-less-color: #242424;
-  --scm-secondary-color: #fafafa;
-  --scm-secondary-more-color: whitesmoke;
-  --scm-secondary-most-color: white;
-}
-
 .swagger-ui {
   color: var(--scm-secondary-text);
 }
@@ -104,7 +53,7 @@
   color: var(--scm-secondary-text)
 }
 
-.swagger-ui .authorization__btn.unlocked {
+.swagger-ui .authorization__btn {
   fill: var(--scm-secondary-text);
 }
 
@@ -310,9 +259,14 @@
   color: #fff
 }
 
+.swagger-ui .opblock-body pre.microlight code {
+  color: white;
+}
+
 .swagger-ui .download-contents {
-  background: #7d8293;
-  color: #fff;
+  border: 1px solid #fff;
+  background: var(--scm-dark-color);
+  color: #fff
 }
 
 .swagger-ui .scheme-container {
@@ -405,11 +359,17 @@
 }
 
 .swagger-ui .copy-to-clipboard {
-  background: #7d8293;
+  border: 1px solid #fff;
+  background: var(--scm-dark-color)
 }
 
 .swagger-ui .copy-to-clipboard button {
   background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" aria-hidden="true"><path fill="%23fff" fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"/></svg>') 50% no-repeat
+}
+
+.swagger-ui .curl-command .copy-to-clipboard {
+  width: 22px;
+  height: 22px;
 }
 
 .swagger-ui select {
@@ -446,7 +406,8 @@
 .swagger-ui input[type=text],
 .swagger-ui textarea {
   border: 1px solid #d9d9d9;
-  background: #fff
+  color: var(--scm-secondary-text);
+  background: var(--scm-secondary-background)
 }
 
 .swagger-ui input[type=email].invalid,
@@ -456,7 +417,7 @@
 .swagger-ui input[type=text].invalid,
 .swagger-ui textarea.invalid {
   border-color: var(--scm-danger-color);
-  background: #feebeb
+  background: var(--scm-secondary-less-color)
 }
 
 .swagger-ui input[disabled],
@@ -476,7 +437,7 @@
 }
 
 .swagger-ui textarea {
-  background: hsla(0, 0%, 100%, .8);
+  background: var(--scm-secondary-background);
   color: var(--scm-secondary-text)
 }
 
@@ -537,7 +498,7 @@
 }
 
 .swagger-ui .model {
-  color: var(--scm-secondary-text)
+  color: var(--scm-dark-color);
 }
 
 .swagger-ui .model .deprecated span,
@@ -545,7 +506,6 @@
   color: #a0a0a0!important
 }
 
-/*TODO: replace for schema in endpoint view */
 .swagger-ui .model-toggle:after {
   background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>') 50% no-repeat;
 }
@@ -595,23 +555,17 @@
   color: #707070
 }
 
-/* todo check */
-.swagger-ui section.models .model-container {
-  background: rgba(0, 0, 0, .05)
-}
-
-/* todo check */
+.swagger-ui section.models .model-container,
 .swagger-ui section.models .model-container:hover {
-  background: rgba(0, 0, 0, .07)
+  background: var(--scm-light-color)
 }
 
-/* todo check */
 .swagger-ui .model-box {
-  background: rgba(0, 0, 0, .1)
+  background: var(--scm-light-color)
 }
 
 .swagger-ui .model-title {
-  color: var(--scm-secondary-color)
+  color: var(--scm-dark-color)
 }
 
 .swagger-ui .model-deprecated-warning {
@@ -721,7 +675,7 @@
 }
 
 .swagger-ui .info .title {
-  color: #fafafa;
+  color: inherit;
   font-size: 2rem;
 }
 
@@ -742,7 +696,7 @@
 }
 
 .swagger-ui .auth-container .errors {
-  background-color: #fee;
+  background: var(--scm-secondary-background);
   color: var(--scm-secondary-text)
 }
 

--- a/src/main/js/swaggerUIColors.css
+++ b/src/main/js/swaggerUIColors.css
@@ -20,13 +20,8 @@
   background: var(--scm-secondary-color)
 }
 
-.swagger-ui .opblock.is-open .opblock-summary {
-  border-bottom: 1px solid #000
-}
-
 .swagger-ui .opblock .opblock-section-header {
   background: var(--scm-secondary-less-color);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, .1)
 }
 
 .swagger-ui .opblock .opblock-section-header>label {
@@ -35,12 +30,6 @@
 
 .swagger-ui .opblock .opblock-section-header h4 {
   color: var(--scm-secondary-text)
-}
-
-.swagger-ui .opblock .opblock-summary-method {
-  background: #000;
-  text-shadow: 0 1px 0 rgba(0, 0, 0, .1);
-  color: #fff
 }
 
 .swagger-ui .opblock .opblock-summary-operation-id,
@@ -59,7 +48,6 @@
 
 .swagger-ui .opblock.opblock-post {
   border-color: var(--scm-success-color);
-  background: rgba(73, 204, 144, .1)
 }
 
 .swagger-ui .opblock.opblock-post .opblock-summary-method {
@@ -74,26 +62,8 @@
   background: var(--scm-success-color)
 }
 
-.swagger-ui .opblock.opblock-put {
-  border-color: #fca130;
-  background: rgba(252, 161, 48, .1)
-}
-
-.swagger-ui .opblock.opblock-put .opblock-summary-method {
-  background: #fca130
-}
-
-.swagger-ui .opblock.opblock-put .opblock-summary {
-  border-color: #fca130
-}
-
-.swagger-ui .opblock.opblock-put .tab-header .tab-item.active h4 span:after {
-  background: #fca130
-}
-
 .swagger-ui .opblock.opblock-delete {
   border-color: var(--scm-danger-color);
-  background: rgba(249, 62, 62, .1)
 }
 
 .swagger-ui .opblock.opblock-delete .opblock-summary-method {
@@ -110,7 +80,6 @@
 
 .swagger-ui .opblock.opblock-get {
   border-color: var(--scm-info-color);
-  background: rgba(97, 175, 254, .1)
 }
 
 .swagger-ui .opblock.opblock-get .opblock-summary-method {
@@ -125,94 +94,8 @@
   background: var(--scm-info-color)
 }
 
-.swagger-ui .opblock.opblock-patch {
-  border-color: #50e3c2;
-  background: rgba(80, 227, 194, .1)
-}
-
-.swagger-ui .opblock.opblock-patch .opblock-summary-method {
-  background: #50e3c2
-}
-
-.swagger-ui .opblock.opblock-patch .opblock-summary {
-  border-color: #50e3c2
-}
-
-.swagger-ui .opblock.opblock-patch .tab-header .tab-item.active h4 span:after {
-  background: #50e3c2
-}
-
-.swagger-ui .opblock.opblock-head {
-  border-color: #9012fe;
-  background: rgba(144, 18, 254, .1)
-}
-
-.swagger-ui .opblock.opblock-head .opblock-summary-method {
-  background: #9012fe
-}
-
-.swagger-ui .opblock.opblock-head .opblock-summary {
-  border-color: #9012fe
-}
-
-.swagger-ui .opblock.opblock-head .tab-header .tab-item.active h4 span:after {
-  background: #9012fe
-}
-
-.swagger-ui .opblock.opblock-options {
-  border-color: #0d5aa7;
-  background: rgba(13, 90, 167, .1)
-}
-
-.swagger-ui .opblock.opblock-options .opblock-summary-method {
-  background: #0d5aa7
-}
-
-.swagger-ui .opblock.opblock-options .opblock-summary {
-  border-color: #0d5aa7
-}
-
-.swagger-ui .opblock.opblock-options .tab-header .tab-item.active h4 span:after {
-  background: #0d5aa7
-}
-
-.swagger-ui .opblock.opblock-deprecated {
-  border-color: #ebebeb;
-  background: hsla(0, 0%, 92.2%, .1)
-}
-
-.swagger-ui .opblock.opblock-deprecated .opblock-summary-method {
-  background: #ebebeb
-}
-
-.swagger-ui .opblock.opblock-deprecated .opblock-summary {
-  border-color: #ebebeb
-}
-
-.swagger-ui .opblock.opblock-deprecated .tab-header .tab-item.active h4 span:after {
-  background: #ebebeb
-}
-
-.swagger-ui .filter .operation-filter-input {
-  border: 2px solid #d8dde7
-}
-
-.swagger-ui .download-url-wrapper .failed,
-.swagger-ui .filter .failed {
-  color: red
-}
-
-.swagger-ui .download-url-wrapper .loading,
-.swagger-ui .filter .loading {
-  color: #aaa
-}
-
 .swagger-ui .tab li {
   color: var(--scm-secondary-text)
-}
-
-.swagger-ui .tab li:first-of-type:after {
-  background: rgba(0, 0, 0, .2)
 }
 
 .swagger-ui .opblock-description-wrapper,
@@ -242,21 +125,8 @@
   color: var(--scm-secondary-text)
 }
 
-.swagger-ui .response-col_status .response-undocumented {
-  color: #909090
-}
-
 .swagger-ui .response-col_links {
   color: var(--scm-secondary-text)
-}
-
-.swagger-ui .response-col_links .response-undocumented {
-  color: #909090
-}
-
-.swagger-ui .opblock-body pre.microlight {
-  background: #333;
-  color: #fff
 }
 
 .swagger-ui .opblock-body pre.microlight code {
@@ -281,53 +151,12 @@
   color: var(--scm-secondary-text)
 }
 
-.swagger-ui .loading-container .loading:before {
-  border: 2px solid rgba(85, 85, 85, .1);
-  border-top-color: rgba(0, 0, 0, .6);
-}
-
-.swagger-ui .response-control-media-type--accept-controller select {
-  border-color: green
-}
-
-.swagger-ui .response-control-media-type__accept-message {
-  color: green;
-}
-
 .swagger-ui section h3 {
   color: var(--scm-secondary-text)
 }
 
-.swagger-ui .fallback {
-  color: #aaa
-}
-
-.swagger-ui .version-pragma__message code {
-  background-color: #dedede;
-}
-
-.swagger-ui span.token-string {
-  color: #555
-}
-
-.swagger-ui span.token-not-formatted {
-  color: #555;
-}
-
 .swagger-ui .btn {
-  border: 2px solid grey;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, .1);
   color: var(--scm-secondary-text)
-}
-
-.swagger-ui .btn:hover {
-  box-shadow: 0 0 5px rgba(0, 0, 0, .3)
-}
-
-.swagger-ui .btn.cancel {
-  border-color: #ff6060;
-  background-color: transparent;
-  color: #ff6060
 }
 
 .swagger-ui .btn.authorize {
@@ -341,30 +170,16 @@
 
 .swagger-ui .btn.execute {
   background-color: var(--scm-info-color);
-  color: #fff;
   border-color: var(--scm-info-color)
-}
-
-.swagger-ui .expand-methods:hover svg {
-  fill: #404040
-}
-
-.swagger-ui .expand-methods svg {
-  fill: #707070
 }
 
 .swagger-ui button.invalid {
   border-color: var(--scm-danger-color);
-  background: #feebeb
 }
 
 .swagger-ui .copy-to-clipboard {
   border: 1px solid #fff;
   background: var(--scm-dark-color)
-}
-
-.swagger-ui .copy-to-clipboard button {
-  background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" aria-hidden="true"><path fill="%23fff" fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"/></svg>') 50% no-repeat
 }
 
 .swagger-ui .curl-command .copy-to-clipboard {
@@ -373,12 +188,10 @@
 }
 
 .swagger-ui select {
-  border: 2px solid #41444e;
   /* use default select arrow instead */
   background: var(--scm-secondary-background);
   appearance: auto;
   padding: 5px 10px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, .25);
   color: var(--scm-secondary-text);
 }
 
@@ -386,13 +199,8 @@
   fill: var(--scm-secondary-text);
 }
 
-.swagger-ui select[multiple] {
-  background: #f7f7f7
-}
-
 .swagger-ui select.invalid {
   border-color: var(--scm-danger-color);
-  background: #feebeb
 }
 
 .swagger-ui label {
@@ -405,7 +213,6 @@
 .swagger-ui input[type=search],
 .swagger-ui input[type=text],
 .swagger-ui textarea {
-  border: 1px solid #d9d9d9;
   color: var(--scm-secondary-text);
   background: var(--scm-secondary-background)
 }
@@ -420,61 +227,22 @@
   background: var(--scm-secondary-less-color)
 }
 
-.swagger-ui input[disabled],
-.swagger-ui select[disabled],
-.swagger-ui textarea[disabled] {
-  background-color: #fafafa;
-  color: #888;
-}
-
-.swagger-ui select[disabled] {
-  border-color: #888
-}
-
-.swagger-ui textarea[disabled] {
-  background-color: #41444e;
-  color: #fff
-}
-
 .swagger-ui textarea {
   background: var(--scm-secondary-background);
   color: var(--scm-secondary-text)
 }
 
 .swagger-ui textarea:focus {
-  border: 2px solid var(--scm-info-color)
-}
-
-.swagger-ui textarea.curl {
-  background: #41444e;
-  color: #fff
-}
-
-.swagger-ui .checkbox {
-  color: #303030
+  border-color: var(--scm-info-color)
 }
 
 .swagger-ui .checkbox p {
   color: var(--scm-secondary-text)
 }
 
-.swagger-ui .checkbox input[type=checkbox]+label>.item {
-  background: #e8e8e8;
-  box-shadow: 0 0 0 2px #e8e8e8;
-}
-
-.swagger-ui .checkbox input[type=checkbox]:checked+label>.item {
-  background: #e8e8e8 url('data:image/svg+xml;charset=utf-8,<svg width="10" height="8" viewBox="3 7 10 8" xmlns="http://www.w3.org/2000/svg"><path fill="%2341474E" fill-rule="evenodd" d="M6.333 15L3 11.667l1.333-1.334 2 2L11.667 7 13 8.333z"/></svg>') 50% no-repeat
-}
-
-.swagger-ui .dialog-ux .backdrop-ux {
-  background: rgba(0, 0, 0, .8)
-}
-
 .swagger-ui .dialog-ux .modal-ux {
   border: var(--scm-border);
   background: var(--scm-secondary-less-color);
-  box-shadow: 0 10px 30px 0 rgba(0, 0, 0, .2)
 }
 
 .swagger-ui .dialog-ux .modal-ux-content p {
@@ -501,40 +269,6 @@
   color: var(--scm-dark-color);
 }
 
-.swagger-ui .model .deprecated span,
-.swagger-ui .model .deprecated td {
-  color: #a0a0a0!important
-}
-
-.swagger-ui .model-toggle:after {
-  background: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>') 50% no-repeat;
-}
-
-.swagger-ui .model-hint {
-  color: #ebebeb;
-  background: rgba(0, 0, 0, .7)
-}
-
-.swagger-ui .model .property {
-  color: #999;
-}
-
-.swagger-ui .model .property.primitive {
-  color: #6b6b6b
-}
-
-.swagger-ui table.model tr.description {
-  color: #666;
-}
-
-.swagger-ui table.model tr.property-row .star {
-  color: red
-}
-
-.swagger-ui table.model tr.extension {
-  color: #777
-}
-
 .swagger-ui section.models {
   border: var(--scm-border);
 }
@@ -545,14 +279,6 @@
 
 .swagger-ui section.models h4 {
   color: var(--scm-secondary-more-color)
-}
-
-.swagger-ui section.models h4:hover {
-  background: rgba(0, 0, 0, .02)
-}
-
-.swagger-ui section.models h5 {
-  color: #707070
 }
 
 .swagger-ui section.models .model-container,
@@ -572,10 +298,6 @@
   color: var(--scm-danger-color)
 }
 
-.swagger-ui .prop-type {
-  color: #55a
-}
-
 .swagger-ui .prop-format {
   color: var(--scm-secondary-more-color)
 }
@@ -588,64 +310,13 @@
   color: var(--scm-secondary-text)
 }
 
-.swagger-ui table.headers .header-example {
-  color: #999;
-}
-
 .swagger-ui table thead tr td,
 .swagger-ui table thead tr th {
-  border-bottom: 1px solid rgba(59, 65, 81, .2);
   color: var(--scm-secondary-text)
 }
 
 .swagger-ui .parameter__name {
   color: var(--scm-secondary-text)
-}
-
-.swagger-ui .parameter__name.required span {
-  color: red
-}
-
-.swagger-ui .parameter__name.required:after {
-  color: rgba(255, 0, 0, .6)
-}
-
-.swagger-ui .parameter__extension,
-.swagger-ui .parameter__in {
-  color: grey
-}
-
-.swagger-ui .parameter__deprecated {
-  color: red
-}
-
-.swagger-ui .response__extension {
-  color: grey
-}
-
-.swagger-ui .topbar {
-  background-color: #1b1b1b
-}
-
-.swagger-ui .topbar a {
-  color: #fff
-}
-
-.swagger-ui .topbar .download-url-wrapper input[type=text] {
-  border: 2px solid #62a03f;
-}
-
-.swagger-ui .topbar .download-url-wrapper .select-label {
-  color: #f0f0f0
-}
-
-.swagger-ui .topbar .download-url-wrapper .select-label select {
-  border: 2px solid #62a03f;
-}
-
-.swagger-ui .topbar .download-url-wrapper .download-url-button {
-  background: #62a03f;
-  color: #fff
 }
 
 .swagger-ui .info li,
@@ -679,18 +350,6 @@
   font-size: 2rem;
 }
 
-.swagger-ui .info .title small {
-  background: #7d8492
-}
-
-.swagger-ui .info .title small.version-stamp {
-  background-color: #89bf04
-}
-
-.swagger-ui .info .title small pre {
-  color: #fff
-}
-
 .swagger-ui .auth-container {
   border-bottom: var(--scm-border)
 }
@@ -709,8 +368,7 @@
 }
 
 .swagger-ui .errors-wrapper {
-  border: 2px solid var(--scm-danger-color);
-  background: rgba(249, 62, 62, .1)
+  border-color: var(--scm-danger-color);
 }
 
 .swagger-ui .errors-wrapper .errors h4 {
@@ -723,15 +381,4 @@
 
 .swagger-ui .errors-wrapper hgroup h4 {
   color: var(--scm-secondary-text)
-}
-
-.swagger-ui .markdown pre,
-.swagger-ui .renderedMarkdown pre {
-  color: #000;
-}
-
-.swagger-ui .markdown code,
-.swagger-ui .renderedMarkdown code {
-  background: rgba(0, 0, 0, .05);
-  color: #9012fe
 }


### PR DESCRIPTION
## Proposed changes

Overrides swagger ui theme with more scmm like that can handle the different scmm themes.

### Your checklist for this pull request

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
